### PR TITLE
Gradle, support libraries and Kotlin version update 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.KOTLIN_VERSION = '1.2.21'
+    ext.KOTLIN_VERSION = '1.2.30'
     ext.ANDROID_GRADLE_PLUGIN_VERSION = '3.0.1'
     ext.DOKKA_VERSION = '0.9.16-eap-2'
     ext.BINTRAY_VERSION = '1.7.3'
@@ -34,7 +34,7 @@ configure(allprojects) {
         ANDROID_COMPILE_SDK_VERSION     = 27
         ANDROID_BUILD_TOOLS_VERSION     = '27.0.3'
 
-        ANDROID_SUPPORT_LIBRARY_VERSION = '27.0.2'
+        ANDROID_SUPPORT_LIBRARY_VERSION = '27.1.0'
         CONSTRAINT_LAYOUT_VERSION       = '1.0.2'
         BUTTERKNIFE_VERSION             = '8.7.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
firstly, thank you for your library, great work.

Secondly, As mixing versions of support libraries could lead to runtime crashes
so I have decided to update them and push that to you

And here is the specific warning, I'm getting when using the library with the support library v27.1.0

`All com.android.support libraries must use the exact same version specification (mixing versions can lead to runtime crashes). Found versions 27.1.0, 27.0.2. Examples include com.android.support:animated-vector-drawable:27.1.0 and com.android.support:recyclerview-v7:27.0.2`