### PR TITLE
Fixed incorrect background selectors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+### Fixed
+- Overriding of Android Themes as raised by @plshapkin in #18. This introduces breaking changes hence 2.0.0 version update.
+
 ## [1.4.2]
 ### Changed
 - Updated Android Support Library to 27.1.0
@@ -40,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 Initial release of the library.
 
+[2.0.0]: https://github.com/zawadz88/MaterialPopupMenu/compare/1.4.2...2.0.0
 [1.4.2]: https://github.com/zawadz88/MaterialPopupMenu/compare/1.4.1...1.4.2
 [1.4.1]: https://github.com/zawadz88/MaterialPopupMenu/compare/1.4.0...1.4.1
 [1.4.0]: https://github.com/zawadz88/MaterialPopupMenu/compare/1.3.0...1.4.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library allows to create simple popup menus programmatically with a nice [t
 
 ## Download (from JCenter)
 ```groovy
-compile 'com.github.zawadz88.materialpopupmenu:material-popup-menu:1.4.2'
+implementation 'com.github.zawadz88.materialpopupmenu:material-popup-menu:2.0.0'
 ```
 
 ## Getting started
@@ -131,7 +131,7 @@ To achieve the above you need to set `labelColor` and `iconColor` on each item i
 ```kotlin
     fun onCustomColorsClicked(view: View) {
         val popupMenu = popupMenu {
-            style = R.style.Widget_MPM_Menu_CustomBackground
+            style = R.style.Widget_MPM_Menu_Dark_CustomBackground
             section {
                 item {
                     label = "Copy"
@@ -173,17 +173,11 @@ To change the popup background color you need to create a custom style and pass 
 E.g. to use the primary color you could define the style like this:
 ```xml
 <resources>
-    <style name="Widget.MPM.Menu.CustomBackground">
-        <item name="mpm_theme">@style/AppTheme.CustomBackground</item>
-    </style>
-
-    <style name="AppTheme.CustomBackground" parent="Theme.AppCompat">
+    <style name="Widget.MPM.Menu.Dark.CustomBackground">
         <item name="android:colorBackground">@color/colorPrimary</item>
     </style>
 </resources>
 ```
-
-`mpm_theme` is used to override the default Activity theme.
 
 ## Documentation
 HTML documentation of the current version of the library is available [here](https://zawadz88.github.io/MaterialPopupMenu/material-popup-menu/).

--- a/material-popup-menu/build.gradle
+++ b/material-popup-menu/build.gradle
@@ -75,7 +75,7 @@ ext {
     siteUrl = 'https://github.com/zawadz88/MaterialPopupMenu'
     gitUrl = 'https://github.com/zawadz88/MaterialPopupMenu.git'
 
-    libraryVersion = '1.4.2'
+    libraryVersion = '2.0.0'
 
     developerId = 'zawadz88'
     developerName = 'Piotr Zawadzki'

--- a/material-popup-menu/src/main/java/android/support/v7/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/android/support/v7/widget/MaterialRecyclerViewPopupWindow.kt
@@ -86,7 +86,7 @@ class MaterialRecyclerViewPopupWindow(
 
     init {
         contextThemeWrapper = ContextThemeWrapper(context, null)
-        contextThemeWrapper.setTheme(getWrapperTheme(context, defStyleRes))
+        contextThemeWrapper.setTheme(defStyleRes)
 
         popup = AppCompatPopupWindow(contextThemeWrapper, null, 0, defStyleRes)
         popup.inputMethodMode = PopupWindow.INPUT_METHOD_NEEDED
@@ -102,15 +102,6 @@ class MaterialRecyclerViewPopupWindow(
         dropDownHorizontalOffset = a.getDimensionPixelOffset(
                 android.support.v7.appcompat.R.styleable.ListPopupWindow_android_dropDownHorizontalOffset, 0)
         a.recycle()
-    }
-
-    @StyleRes
-    private fun getWrapperTheme(context: Context, @StyleRes defStyleRes: Int): Int {
-        val a = context.obtainStyledAttributes(null,
-                R.styleable.MaterialRecyclerViewPopupWindow, 0, defStyleRes)
-        val themeResource = a.getResourceId(R.styleable.MaterialRecyclerViewPopupWindow_mpm_theme, 0)
-        a.recycle()
-        return themeResource
     }
 
     /**

--- a/material-popup-menu/src/main/res/values/attrs.xml
+++ b/material-popup-menu/src/main/res/values/attrs.xml
@@ -9,10 +9,4 @@
 
     <attr name="mpm_separatorColor" format="color|reference" />
 
-    <declare-styleable name="MaterialRecyclerViewPopupWindow">
-
-        <attr name="mpm_theme" format="reference" />
-
-    </declare-styleable>
-
 </resources>

--- a/material-popup-menu/src/main/res/values/styles.xml
+++ b/material-popup-menu/src/main/res/values/styles.xml
@@ -1,19 +1,21 @@
 <resources>
 
     <style name="Widget.MPM.Menu" parent="Widget.AppCompat.PopupMenu.Overflow">
+        <item name="android:colorBackground">@color/mpm_material_grey_50</item>
+        <item name="android:theme">@style/Theme.AppCompat.Light</item>
         <item name="mpm_primaryTextColor">@color/mpm_black_87_opacity</item>
         <item name="mpm_secondaryTextColor">@color/mpm_black_54_opacity</item>
         <item name="mpm_activeIconColor">@color/mpm_black_54_opacity</item>
         <item name="mpm_separatorColor">@color/mpm_black_12_opacity</item>
-        <item name="mpm_theme">@style/Theme.AppCompat.Light</item>
     </style>
 
     <style name="Widget.MPM.Menu.Dark">
+        <item name="android:colorBackground">@color/mpm_material_grey_850</item>
+        <item name="android:theme">@style/Theme.AppCompat</item>
         <item name="mpm_primaryTextColor">@color/mpm_white</item>
         <item name="mpm_secondaryTextColor">@color/mpm_white_70_opacity</item>
         <item name="mpm_activeIconColor">@color/mpm_white</item>
         <item name="mpm_separatorColor">@color/mpm_white_12_opacity</item>
-        <item name="mpm_theme">@style/Theme.AppCompat</item>
     </style>
 
     <style name="Widget.MPM.Item" parent="">

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -210,7 +210,7 @@ class DarkActivity : AppCompatActivity() {
     @OnClick(R.id.customColorsTextView)
     fun onCustomColorsClicked(view: View) {
         val popupMenu = popupMenu {
-            style = R.style.Widget_MPM_Menu_CustomBackground
+            style = R.style.Widget_MPM_Menu_Dark_CustomBackground
             section {
                 item {
                     label = "Copy"

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -204,7 +204,7 @@ class LightActivity : AppCompatActivity() {
     @OnClick(R.id.customColorsTextView)
     fun onCustomColorsClicked(view: View) {
         val popupMenu = popupMenu {
-            style = R.style.Widget_MPM_Menu_CustomBackground
+            style = R.style.Widget_MPM_Menu_Dark_CustomBackground
             section {
                 item {
                     label = "Copy"

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -40,11 +40,7 @@
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Caption</item>
     </style>
 
-    <style name="Widget.MPM.Menu.CustomBackground">
-        <item name="mpm_theme">@style/AppTheme.CustomBackground</item>
-    </style>
-
-    <style name="AppTheme.CustomBackground" parent="Theme.AppCompat">
+    <style name="Widget.MPM.Menu.Dark.CustomBackground">
         <item name="android:colorBackground">@color/colorPrimary</item>
     </style>
 


### PR DESCRIPTION
This fixes incorrect background selectors so that if we want to use a dark popup in a Light-themed Activity the highlight colors would be correct when items are touched. This was initially done in #12 , but due to an issue raised in #18 this needed refactoring (@plshapkin thanks for fixing the Theme issue!).

Version update to 2.0.0. Major version update is due to dropping `mpm_theme` attribute, which was removed as the same thing can be accomplished with `android:theme`, which is supported through AppCompat on older devices as well.
