### PR TITLE
Allow setting item label via string resource

### DIFF
--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.annotation.UiThread
 import androidx.appcompat.widget.MaterialRecyclerViewPopupWindow
@@ -74,7 +75,8 @@ class MaterialPopupMenu internal constructor(
     )
 
     internal data class PopupMenuItem(
-        val label: String,
+        val label: String?,
+        @StringRes val labelRes: Int,
         @ColorInt val labelColor: Int,
         @DrawableRes val icon: Int,
         val iconDrawable: Drawable?,

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.annotation.LayoutRes
+import androidx.annotation.StringRes
 
 /**
  * Builder for creating a [MaterialPopupMenu].
@@ -119,9 +120,26 @@ class MaterialPopupMenuBuilder {
     class ItemHolder : AbstractItemHolder() {
 
         /**
-         * Item label. This is a required field and must not be *null*.
+         * Item label.
+         *
+         * This is a required field and must not be *null*, unless you specify a label
+         * using [labelRes].
+         *
+         * If both [label] and [labelRes] are set [label] will be used.
          */
         var label: String? = null
+
+        /**
+         * Item label.
+         *
+         * This must be a valid string resource ID if set.
+         * This is a required field and must not be *0*, unless you specify a label
+         * using [label].
+         *
+         * If both [label] and [labelRes] are set [label] will be used.
+         */
+        @StringRes
+        var labelRes: Int = 0
 
         /**
          * Optional text color of the label. If not set or 0 the default color will be used.
@@ -163,12 +181,14 @@ class MaterialPopupMenuBuilder {
         var iconColor: Int = 0
 
         override fun toString(): String {
-            return "ItemHolder(label=$label, labelColor=$labelColor, icon=$icon, iconDrawable=$iconDrawable, iconColor=$iconColor, callback=$callback, dismissOnSelect=$dismissOnSelect)"
+            return "ItemHolder(label=$label, labelRes=$labelRes, labelColor=$labelColor, icon=$icon, iconDrawable=$iconDrawable, iconColor=$iconColor, callback=$callback, dismissOnSelect=$dismissOnSelect)"
         }
 
         override fun convertToPopupMenuItem(): MaterialPopupMenu.PopupMenuItem {
+            require(label != null || labelRes != 0) { "Item '$this' does not have a label" }
             return MaterialPopupMenu.PopupMenuItem(
-                    label = checkNotNull(label) { "Item '$this' does not have a label" },
+                    label = label,
+                    labelRes = labelRes,
                     labelColor = labelColor,
                     icon = icon,
                     iconDrawable = iconDrawable,

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
@@ -101,7 +101,11 @@ internal class PopupMenuAdapter(
 
         override fun bindItem(popupMenuItem: MaterialPopupMenu.AbstractPopupMenuItem) {
             val castedPopupMenuItem = popupMenuItem as MaterialPopupMenu.PopupMenuItem
-            label.text = castedPopupMenuItem.label
+            if (castedPopupMenuItem.label != null) {
+                label.text = castedPopupMenuItem.label
+            } else {
+                label.setText(castedPopupMenuItem.labelRes)
+            }
             if (castedPopupMenuItem.icon != 0 || castedPopupMenuItem.iconDrawable != null) {
                 icon.apply {
                     visibility = View.VISIBLE

--- a/material-popup-menu/src/main/res/values/strings.xml
+++ b/material-popup-menu/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="copy">Copy</string>
+</resources>

--- a/material-popup-menu/src/main/res/values/strings.xml
+++ b/material-popup-menu/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="copy">Copy</string>
-</resources>

--- a/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
+++ b/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
@@ -20,6 +20,7 @@ class MaterialPopupMenuBuilderTest {
         private const val ITEM_LABEL = "item label"
         private const val ITEM_LABEL2 = "item label2"
         private const val ITEM_LABEL3 = "item label3"
+        private const val ITEM_LABEL_RES = 777
         private const val ITEM_LABEL_TEXT_COLOR = 123
         private const val ITEM_ICON_TINT_COLOR = 888
         private const val ITEM_ICON = -1
@@ -292,12 +293,34 @@ class MaterialPopupMenuBuilderTest {
         val item = section.items[0]
         assertThat(item, instanceOf(MaterialPopupMenu.PopupMenuItem::class.java))
         val popupMenuItem = item as MaterialPopupMenu.PopupMenuItem
-        val (_, _, _, _, _, callback) = popupMenuItem
+        val (_, _, _, _, _, _, callback) = popupMenuItem
 
         //when
         callback()
 
         //then
         //nothing to do here...
+    }
+
+    @Test
+    fun `Should build a popup menu with a String resource label`() {
+        //when
+        val popupMenu = popupMenu {
+            section {
+                item {
+                    labelRes = ITEM_LABEL_RES
+                }
+            }
+        }
+
+        //then
+        assertThat("Should contain one section", popupMenu.sections, hasSize(1))
+        val section = popupMenu.sections[0]
+        assertThat("Should contain a single item", section.items, hasSize(1))
+        val item = section.items[0]
+        assertThat(item, instanceOf(MaterialPopupMenu.PopupMenuItem::class.java))
+        val popupMenuItem = item as MaterialPopupMenu.PopupMenuItem
+        assertNull("Invalid item label", popupMenuItem.label)
+        assertEquals("Invalid item label resource", ITEM_LABEL_RES, popupMenuItem.labelRes)
     }
 }

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -59,7 +59,7 @@ class DarkActivity : AppCompatActivity() {
                 section {
                     title = "Editing"
                     item {
-                        label = "Copy"
+                        labelRes = R.string.copy
                         icon = R.drawable.abc_ic_menu_copy_mtrl_am_alpha
                         callback = {
                             Toast.makeText(this@DarkActivity, "Copied!", Toast.LENGTH_SHORT).show()
@@ -92,7 +92,7 @@ class DarkActivity : AppCompatActivity() {
             style = R.style.Widget_MPM_Menu_Dark
             section {
                 item {
-                    label = "Copy"
+                    labelRes = R.string.copy
                     icon = R.drawable.abc_ic_menu_copy_mtrl_am_alpha
                     callback = {
                         Toast.makeText(this@DarkActivity, "Copied!", Toast.LENGTH_SHORT).show()

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -14,4 +14,5 @@
     <string name="show_share_section">Show Share section</string>
     <string name="custom_items">Custom items</string>
     <string name="custom_item_label">Enabled</string>
+    <string name="copy">Copy</string>
 </resources>


### PR DESCRIPTION
This pull request adds a way to set item labels by using string resources instead of regular strings.

Example:

```kt
val popupMenu = popupMenu {
    section {
        item {
            labelRes = R.string.copy
        }
    }
}
```