### PR TITLE
Add flag to dim background behind popup

### DIFF
--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -37,6 +37,7 @@ class MaterialRecyclerViewPopupWindow(
     companion object {
 
         private const val TAG = "MaterialRVPopupWindow"
+        private const val DEFAULT_BACKGROUND_DIM_AMOUNT = 0.3f
 
         private var sClipToWindowEnabledMethod: Method? = null
         private var sGetMaxAvailableHeightMethod: Method? = null
@@ -89,6 +90,14 @@ class MaterialRecyclerViewPopupWindow(
 
     private val contextThemeWrapper: Context
 
+    private val windowManager: WindowManager by lazy {
+        context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    }
+
+    private val backgroundDimEnabled: Boolean
+
+    private val backgroundDimAmount: Float
+
     init {
         contextThemeWrapper = ContextThemeWrapper(context, null)
         contextThemeWrapper.setTheme(defStyleRes)
@@ -101,10 +110,12 @@ class MaterialRecyclerViewPopupWindow(
         popupMinWidth = contextThemeWrapper.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_min_width)
         popupWidthUnit = contextThemeWrapper.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_width_unit)
 
-        val a = context.obtainStyledAttributes(null, androidx.appcompat.R.styleable.ListPopupWindow, 0, defStyleRes)
+        val a = context.obtainStyledAttributes(null, R.styleable.MaterialRecyclerViewPopupWindow, 0, defStyleRes)
 
-        dropDownHorizontalOffset = a.getDimensionPixelOffset(androidx.appcompat.R.styleable.ListPopupWindow_android_dropDownHorizontalOffset, 0)
-        dropDownVerticalOffset = a.getDimensionPixelOffset(androidx.appcompat.R.styleable.ListPopupWindow_android_dropDownVerticalOffset, 0)
+        dropDownHorizontalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownHorizontalOffset, 0)
+        dropDownVerticalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownVerticalOffset, 0)
+        backgroundDimEnabled = a.getBoolean(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimEnabled, false)
+        backgroundDimAmount = a.getFloat(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimAmount, DEFAULT_BACKGROUND_DIM_AMOUNT)
 
         a.recycle()
     }
@@ -157,6 +168,10 @@ class MaterialRecyclerViewPopupWindow(
                 popup, anchorView!!, dropDownHorizontalOffset,
                 dropDownVerticalOffset, dropDownGravity
             )
+        }
+
+        if (backgroundDimEnabled) {
+            addBackgroundDimming()
         }
     }
 
@@ -358,5 +373,13 @@ class MaterialRecyclerViewPopupWindow(
         menuWidth = Math.ceil(menuWidth.toDouble() / popupWidthUnit).toInt() * popupWidthUnit
 
         return menuWidth
+    }
+
+    private fun addBackgroundDimming() {
+        val decorView = popup.contentView.rootView
+        val layoutParams = decorView.layoutParams as WindowManager.LayoutParams
+        layoutParams.flags = WindowManager.LayoutParams.FLAG_DIM_BEHIND
+        layoutParams.dimAmount = backgroundDimAmount
+        windowManager.updateViewLayout(decorView, layoutParams)
     }
 }

--- a/material-popup-menu/src/main/res/values/attrs.xml
+++ b/material-popup-menu/src/main/res/values/attrs.xml
@@ -9,4 +9,11 @@
 
     <attr name="mpm_separatorColor" format="color|reference" />
 
+    <declare-styleable name="MaterialRecyclerViewPopupWindow">
+        <attr name="android:dropDownHorizontalOffset" />
+        <attr name="android:dropDownVerticalOffset" />
+        <attr name="android:backgroundDimEnabled" />
+        <attr name="android:backgroundDimAmount" />
+    </declare-styleable>
+
 </resources>

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -291,6 +291,22 @@ class DarkActivity : AppCompatActivity() {
         popupMenu.show(this@DarkActivity, view)
     }
 
+    @OnClick(R.id.dimmedBackgroundTextView)
+    fun onDimmedBackgroundClicked(view: View) {
+        val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_Dark_Dimmed
+            section {
+                item {
+                    label = "Copy"
+                }
+                item {
+                    label = "Paste"
+                }
+            }
+        }
+        popupMenu.show(this@DarkActivity, view)
+    }
+
     @OnClick(R.id.customItemsTextView)
     fun onCustomItemsClicked(view: View) {
         val popupMenu = popupMenu {

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -317,6 +317,22 @@ class LightActivity : AppCompatActivity() {
         popupMenu.show(this@LightActivity, view)
     }
 
+    @OnClick(R.id.dimmedBackgroundTextView)
+    fun onDimmedBackgroundClicked(view: View) {
+        val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_Dimmed
+            section {
+                item {
+                    label = "Copy"
+                }
+                item {
+                    label = "Paste"
+                }
+            }
+        }
+        popupMenu.show(this@LightActivity, view)
+    }
+
     @OnClick(R.id.conditionalItemsTextView)
     fun onConditionalItemsClicked(view: View) {
         val conditionalPopupMenuBuilder = popupMenuBuilder {

--- a/sample/src/main/res/layout/activity_dark.xml
+++ b/sample/src/main/res/layout/activity_dark.xml
@@ -90,13 +90,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/customColorsTextView" />
 
             <TextView
+                android:id="@+id/dimmedBackgroundTextView"
+                style="@style/TitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/dimmed_background"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
+
+            <TextView
                 android:id="@+id/conditionalItemsTextView"
                 style="@style/TitleLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
+                app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
 
             <TextView
                 android:id="@+id/conditionalItemsCopySubtitleTextView"

--- a/sample/src/main/res/layout/activity_light.xml
+++ b/sample/src/main/res/layout/activity_light.xml
@@ -90,13 +90,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/customColorsTextView" />
 
             <TextView
+                android:id="@+id/dimmedBackgroundTextView"
+                style="@style/TitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/dimmed_background"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
+
+            <TextView
                 android:id="@+id/conditionalItemsTextView"
                 style="@style/TitleLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
+                app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
 
             <TextView
                 android:id="@+id/conditionalItemsCopySubtitleTextView"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -15,4 +15,5 @@
     <string name="custom_items">Custom items</string>
     <string name="custom_item_label">Enabled</string>
     <string name="copy">Copy</string>
+    <string name="dimmed_background">Dimmed background</string>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -54,4 +54,12 @@
         <item name="android:dropDownHorizontalOffset">24dp</item>
     </style>
 
+    <style name="Widget.MPM.Menu.Dimmed">
+        <item name="android:backgroundDimEnabled">true</item>
+    </style>
+
+    <style name="Widget.MPM.Menu.Dark.Dimmed">
+        <item name="android:backgroundDimEnabled">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Can be enabled via style attribute `android:backgroundDimEnabled` and customized with `android:backgroundDimAmount` where amount can be a float number betwen `0.0` and `1.0`.

# Example

<img src="https://user-images.githubusercontent.com/5156340/56084681-cc479900-5e36-11e9-9695-598b7fdf8aa6.png" height="580" /> <img src="https://user-images.githubusercontent.com/5156340/56084682-cea9f300-5e36-11e9-9473-f2289ffb2c92.png" height="580" />

