### PR TITLE
Add a way to customize popup padding

### DIFF
--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -98,6 +98,14 @@ class MaterialRecyclerViewPopupWindow(
 
     private val backgroundDimAmount: Float
 
+    private val popupPaddingBottom: Int
+
+    private val popupPaddingLeft: Int
+
+    private val popupPaddingRight: Int
+
+    private val popupPaddingTop: Int
+
     init {
         contextThemeWrapper = ContextThemeWrapper(context, null)
         contextThemeWrapper.setTheme(defStyleRes)
@@ -116,6 +124,10 @@ class MaterialRecyclerViewPopupWindow(
         dropDownVerticalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownVerticalOffset, 0)
         backgroundDimEnabled = a.getBoolean(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimEnabled, false)
         backgroundDimAmount = a.getFloat(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimAmount, DEFAULT_BACKGROUND_DIM_AMOUNT)
+        popupPaddingBottom = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingBottom, 0)
+        popupPaddingLeft = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingLeft, 0)
+        popupPaddingRight = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingRight, 0)
+        popupPaddingTop = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingTop, 0)
 
         a.recycle()
     }
@@ -211,6 +223,7 @@ class MaterialRecyclerViewPopupWindow(
         dropDownList.layoutManager = LinearLayoutManager(this.contextThemeWrapper)
         dropDownList.isFocusable = true
         dropDownList.isFocusableInTouchMode = true
+        dropDownList.setPadding(popupPaddingLeft, popupPaddingTop, popupPaddingRight, popupPaddingBottom)
 
         popup.contentView = dropDownList
 

--- a/material-popup-menu/src/main/res/layout/mpm_popup_menu.xml
+++ b/material-popup-menu/src/main/res/layout/mpm_popup_menu.xml
@@ -2,6 +2,4 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingTop="@dimen/mpm_popup_menu_vertical_padding"
-    android:paddingBottom="@dimen/mpm_popup_menu_vertical_padding"
     tools:listitem="@layout/mpm_popup_menu_item" />

--- a/material-popup-menu/src/main/res/values/attrs.xml
+++ b/material-popup-menu/src/main/res/values/attrs.xml
@@ -9,11 +9,23 @@
 
     <attr name="mpm_separatorColor" format="color|reference" />
 
+    <attr name="mpm_paddingBottom" format="dimension" />
+
+    <attr name="mpm_paddingLeft" format="dimension" />
+
+    <attr name="mpm_paddingRight" format="dimension" />
+
+    <attr name="mpm_paddingTop" format="dimension" />
+
     <declare-styleable name="MaterialRecyclerViewPopupWindow">
         <attr name="android:dropDownHorizontalOffset" />
         <attr name="android:dropDownVerticalOffset" />
         <attr name="android:backgroundDimEnabled" />
         <attr name="android:backgroundDimAmount" />
+        <attr name="mpm_paddingBottom" />
+        <attr name="mpm_paddingLeft" />
+        <attr name="mpm_paddingRight" />
+        <attr name="mpm_paddingTop" />
     </declare-styleable>
 
 </resources>

--- a/material-popup-menu/src/main/res/values/styles.xml
+++ b/material-popup-menu/src/main/res/values/styles.xml
@@ -7,6 +7,10 @@
         <item name="mpm_secondaryTextColor">@color/mpm_black_54_opacity</item>
         <item name="mpm_activeIconColor">@color/mpm_black_54_opacity</item>
         <item name="mpm_separatorColor">@color/mpm_black_12_opacity</item>
+        <item name="mpm_paddingBottom">@dimen/mpm_popup_menu_vertical_padding</item>
+        <item name="mpm_paddingLeft">0dp</item>
+        <item name="mpm_paddingRight">0dp</item>
+        <item name="mpm_paddingTop">@dimen/mpm_popup_menu_vertical_padding</item>
     </style>
 
     <style name="Widget.MPM.Menu.Dark">
@@ -16,6 +20,10 @@
         <item name="mpm_secondaryTextColor">@color/mpm_white_70_opacity</item>
         <item name="mpm_activeIconColor">@color/mpm_white</item>
         <item name="mpm_separatorColor">@color/mpm_white_12_opacity</item>
+        <item name="mpm_paddingBottom">@dimen/mpm_popup_menu_vertical_padding</item>
+        <item name="mpm_paddingLeft">0dp</item>
+        <item name="mpm_paddingRight">0dp</item>
+        <item name="mpm_paddingTop">@dimen/mpm_popup_menu_vertical_padding</item>
     </style>
 
     <style name="Widget.MPM.Item" parent="">

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -339,6 +339,23 @@ class DarkActivity : AppCompatActivity() {
         popupMenu.show(this@DarkActivity, view)
     }
 
+    @OnClick(R.id.customPaddingTextView)
+    fun onCustomPaddingTextViewClicked(view: View) {
+        val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_Dark_CustomPadding
+            section {
+                item {
+                    label = "Copy"
+                }
+                item {
+                    label = "Paste"
+                }
+            }
+        }
+
+        popupMenu.show(this@DarkActivity, view)
+    }
+
     @OnClick(R.id.conditionalItemsTextView)
     fun onConditionalItemsClicked(view: View) {
         val conditionalPopupMenuBuilder = popupMenuBuilder {

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -333,6 +333,23 @@ class LightActivity : AppCompatActivity() {
         popupMenu.show(this@LightActivity, view)
     }
 
+    @OnClick(R.id.customPaddingTextView)
+    fun onCustomPaddingTextViewClicked(view: View) {
+        val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_CustomPadding
+            section {
+                item {
+                    label = "Copy"
+                }
+                item {
+                    label = "Paste"
+                }
+            }
+        }
+
+        popupMenu.show(this@LightActivity, view)
+    }
+
     @OnClick(R.id.conditionalItemsTextView)
     fun onConditionalItemsClicked(view: View) {
         val conditionalPopupMenuBuilder = popupMenuBuilder {

--- a/sample/src/main/res/layout/activity_dark.xml
+++ b/sample/src/main/res/layout/activity_dark.xml
@@ -99,13 +99,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
 
             <TextView
+                android:id="@+id/customPaddingTextView"
+                style="@style/TitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/custom_padding"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
+
+            <TextView
                 android:id="@+id/conditionalItemsTextView"
                 style="@style/TitleLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
+                app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
 
             <TextView
                 android:id="@+id/conditionalItemsCopySubtitleTextView"

--- a/sample/src/main/res/layout/activity_light.xml
+++ b/sample/src/main/res/layout/activity_light.xml
@@ -99,13 +99,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
 
             <TextView
+                android:id="@+id/customPaddingTextView"
+                style="@style/TitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/custom_padding"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
+
+            <TextView
                 android:id="@+id/conditionalItemsTextView"
                 style="@style/TitleLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
+                app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
 
             <TextView
                 android:id="@+id/conditionalItemsCopySubtitleTextView"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="custom_item_label">Enabled</string>
     <string name="copy">Copy</string>
     <string name="dimmed_background">Dimmed background</string>
+    <string name="custom_padding">Custom padding</string>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -62,4 +62,18 @@
         <item name="android:backgroundDimEnabled">true</item>
     </style>
 
+    <style name="Widget.MPM.Menu.CustomPadding">
+        <item name="mpm_paddingBottom">16dp</item>
+        <item name="mpm_paddingLeft">16dp</item>
+        <item name="mpm_paddingRight">16dp</item>
+        <item name="mpm_paddingTop">16dp</item>
+    </style>
+
+    <style name="Widget.MPM.Menu.Dark.CustomPadding">
+        <item name="mpm_paddingBottom">16dp</item>
+        <item name="mpm_paddingLeft">16dp</item>
+        <item name="mpm_paddingRight">16dp</item>
+        <item name="mpm_paddingTop">16dp</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Added few attributes that allow users to customize the popup padding via style:

- `mpm_paddingBottom`
- `mpm_paddingLeft`
- `mpm_paddingRight`
- `mpm_paddingTop`

# Example

<img src="https://user-images.githubusercontent.com/5156340/56091788-87ae1300-5eb3-11e9-9a20-f6c485f3b1ab.png" height="580" /> <img src="https://user-images.githubusercontent.com/5156340/56091790-8977d680-5eb3-11e9-8034-feb5ed407679.png" height="580" />
