### PR TITLE
Add option to keep popup open after clicking on item

### DIFF
--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -40,7 +40,7 @@ class MaterialPopupMenu internal constructor(
     @UiThread
     fun show(context: Context, anchor: View) {
         val popupWindow = MaterialRecyclerViewPopupWindow(context, dropdownGravity, style)
-        val adapter = PopupMenuAdapter(context, style, sections, { popupWindow.dismiss() })
+        val adapter = PopupMenuAdapter(context, style, sections) { popupWindow.dismiss() }
 
         popupWindow.adapter = adapter
         popupWindow.anchorView = anchor
@@ -79,16 +79,19 @@ class MaterialPopupMenu internal constructor(
         @DrawableRes val icon: Int,
         val iconDrawable: Drawable?,
         @ColorInt val iconColor: Int,
-        override val callback: () -> Unit
-    ) : AbstractPopupMenuItem(callback)
+        override val callback: () -> Unit,
+        override val dismissOnSelect: Boolean
+    ) : AbstractPopupMenuItem(callback, dismissOnSelect)
 
     internal data class PopupMenuCustomItem(
         @LayoutRes val layoutResId: Int,
         val viewBoundCallback: (View) -> Unit,
-        override val callback: () -> Unit
-    ) : AbstractPopupMenuItem(callback)
+        override val callback: () -> Unit,
+        override val dismissOnSelect: Boolean
+    ) : AbstractPopupMenuItem(callback, dismissOnSelect)
 
     internal abstract class AbstractPopupMenuItem(
-        open val callback: () -> Unit
+        open val callback: () -> Unit,
+        open val dismissOnSelect: Boolean
     )
 }

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -163,7 +163,7 @@ class MaterialPopupMenuBuilder {
         var iconColor: Int = 0
 
         override fun toString(): String {
-            return "ItemHolder(label=$label, labelColor=$labelColor, icon=$icon, iconDrawable=$iconDrawable, iconColor=$iconColor, callback=$callback)"
+            return "ItemHolder(label=$label, labelColor=$labelColor, icon=$icon, iconDrawable=$iconDrawable, iconColor=$iconColor, callback=$callback, dismissOnSelect=$dismissOnSelect)"
         }
 
         override fun convertToPopupMenuItem(): MaterialPopupMenu.PopupMenuItem {
@@ -173,7 +173,8 @@ class MaterialPopupMenuBuilder {
                     icon = icon,
                     iconDrawable = iconDrawable,
                     iconColor = iconColor,
-                    callback = callback)
+                    callback = callback,
+                    dismissOnSelect = dismissOnSelect)
         }
 
     }
@@ -197,7 +198,7 @@ class MaterialPopupMenuBuilder {
         var viewBoundCallback: (View) -> Unit = {}
 
         override fun toString(): String {
-            return "CustomItemHolder(layoutResId=$layoutResId, viewBoundCallback=$viewBoundCallback, callback=$callback)"
+            return "CustomItemHolder(layoutResId=$layoutResId, viewBoundCallback=$viewBoundCallback, callback=$callback, dismissOnSelect=$dismissOnSelect)"
         }
 
         override fun convertToPopupMenuItem(): MaterialPopupMenu.PopupMenuCustomItem {
@@ -205,7 +206,8 @@ class MaterialPopupMenuBuilder {
             return MaterialPopupMenu.PopupMenuCustomItem(
                     layoutResId = layoutResId,
                     viewBoundCallback = viewBoundCallback,
-                    callback = callback)
+                    callback = callback,
+                    dismissOnSelect = dismissOnSelect)
         }
 
     }
@@ -217,6 +219,12 @@ class MaterialPopupMenuBuilder {
          * Callback to be invoked once an item gets selected.
          */
         var callback: () -> Unit = {}
+
+        /**
+         * Whether to dismiss the popup once an item gets selected.
+         * Defaults to `true`.
+         */
+        var dismissOnSelect: Boolean = true
 
         internal abstract fun convertToPopupMenuItem(): MaterialPopupMenu.AbstractPopupMenuItem
 

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
@@ -82,7 +82,9 @@ internal class PopupMenuAdapter(
         holder.bindItem(popupMenuItem)
         holder.itemView.setOnClickListener {
             popupMenuItem.callback()
-            onItemClickedCallback(popupMenuItem)
+            if (popupMenuItem.dismissOnSelect) {
+                onItemClickedCallback(popupMenuItem)
+            }
         }
     }
 

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -138,6 +138,13 @@ class DarkActivity : AppCompatActivity() {
                 item {
                     label = "Select all"
                 }
+                item {
+                    label = "Stay open when clicked"
+                    dismissOnSelect = false
+                    callback = {
+                        Toast.makeText(this@DarkActivity, "Clicked!", Toast.LENGTH_SHORT).show()
+                    }
+                }
             }
         }
 

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -135,6 +135,13 @@ class LightActivity : AppCompatActivity() {
                 item {
                     label = "Select all"
                 }
+                item {
+                    label = "Stay open when clicked"
+                    dismissOnSelect = false
+                    callback = {
+                        Toast.makeText(this@LightActivity, "Clicked!", Toast.LENGTH_SHORT).show()
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Adds a way to specify for each item whether clicking on it should dismiss the popup or keep it visible. It can be specified by setting the `dismissOnSelect` property.

# Example
```kt
val popupMenu = popupMenu {
     section {
        /* ... */
        item {
            label = "Stay open when clicked"
            dismissOnSelect = false
            callback = {
                Toast.makeText(this@LightActivity, "Clicked!", Toast.LENGTH_SHORT).show()
            }
        }
    }
}
```

![2019-04-14_13-15-39](https://user-images.githubusercontent.com/5156340/56092118-1329a300-5eb8-11e9-8deb-67783256ee16.gif)
