### PR TITLE
Fix background clipping when using rounded corners

### DIFF
--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -3,6 +3,7 @@ package androidx.appcompat.widget
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Rect
+import android.os.Build
 import android.util.Log
 import android.view.Gravity
 import android.view.View
@@ -224,6 +225,13 @@ class MaterialRecyclerViewPopupWindow(
         dropDownList.isFocusable = true
         dropDownList.isFocusableInTouchMode = true
         dropDownList.setPadding(popupPaddingLeft, popupPaddingTop, popupPaddingRight, popupPaddingBottom)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            dropDownList.clipToOutline = true
+            // Move the background from popup to RecyclerView for clipToOutline to take effect.
+            dropDownList.background = popup.background
+            popup.setBackgroundDrawable(null)
+        }
 
         popup.contentView = dropDownList
 

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -356,6 +356,37 @@ class DarkActivity : AppCompatActivity() {
         popupMenu.show(this@DarkActivity, view)
     }
 
+    @OnClick(R.id.roundedCornersTextView)
+    fun onRoundedCornersClicked(view: View) {
+        val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_Dark_RoundedCorners
+            section {
+                item {
+                    label = "Copy"
+                    icon = R.drawable.abc_ic_menu_copy_mtrl_am_alpha
+                    callback = {
+                        Toast.makeText(this@DarkActivity, "Copied!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                customItem {
+                    layoutResId = R.layout.view_custom_item_checkable
+                    viewBoundCallback = { view ->
+                        val checkBox: CheckBox = view.findViewById(R.id.customItemCheckbox)
+                        checkBox.isChecked = true
+                    }
+                    callback = {
+                        Toast.makeText(this@DarkActivity, "Disabled!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                customItem {
+                    layoutResId = R.layout.view_custom_item_colored
+                }
+            }
+        }
+
+        popupMenu.show(this@DarkActivity, view)
+    }
+
     @OnClick(R.id.conditionalItemsTextView)
     fun onConditionalItemsClicked(view: View) {
         val conditionalPopupMenuBuilder = popupMenuBuilder {

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -3,6 +3,7 @@ package com.github.zawadz88.materialpopupmenu.sample
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -14,6 +15,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.CheckBox
+import android.widget.TextView
 import android.widget.Toast
 import butterknife.BindView
 import butterknife.ButterKnife
@@ -37,11 +39,20 @@ class DarkActivity : AppCompatActivity() {
     @BindView(R.id.sectionConditionalSwitch)
     lateinit var sectionConditionalSwitch: SwitchCompat
 
+    @BindView(R.id.roundedCornersTextView)
+    lateinit var roundedCornersTextView: TextView
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_dark)
         ButterKnife.bind(this)
         setSupportActionBar(toolbar)
+
+        roundedCornersTextView.visibility = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -2,18 +2,20 @@ package com.github.zawadz88.materialpopupmenu.sample
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import androidx.core.content.ContextCompat
-import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.SwitchCompat
-import androidx.appcompat.widget.Toolbar
 import android.view.Gravity
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.CheckBox
+import android.widget.TextView
 import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.SwitchCompat
+import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
@@ -35,11 +37,20 @@ class LightActivity : AppCompatActivity() {
     @BindView(R.id.sectionConditionalSwitch)
     lateinit var sectionConditionalSwitch: SwitchCompat
 
+    @BindView(R.id.roundedCornersTextView)
+    lateinit var roundedCornersTextView: TextView
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_light)
         ButterKnife.bind(this)
         setSupportActionBar(toolbar)
+
+        roundedCornersTextView.visibility = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -350,6 +350,39 @@ class LightActivity : AppCompatActivity() {
         popupMenu.show(this@LightActivity, view)
     }
 
+    @OnClick(R.id.roundedCornersTextView)
+    fun onRoundedCornersClicked(view: View) {
+        val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_RoundedCorners
+            section {
+                item {
+                    label = "Copy"
+                    icon = R.drawable.abc_ic_menu_copy_mtrl_am_alpha
+                    callback = {
+                        Toast.makeText(this@LightActivity, "Copied!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                customItem {
+                    layoutResId = R.layout.view_custom_item_checkable
+                    viewBoundCallback = { view ->
+                        val checkBox: CheckBox = view.findViewById(R.id.customItemCheckbox)
+                        checkBox.isChecked = true
+                    }
+                    callback = {
+                        Toast.makeText(this@LightActivity, "Disabled!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                customItem {
+                    layoutResId = R.layout.view_custom_item_colored
+
+
+                }
+            }
+        }
+
+        popupMenu.show(this@LightActivity, view)
+    }
+
     @OnClick(R.id.conditionalItemsTextView)
     fun onConditionalItemsClicked(view: View) {
         val conditionalPopupMenuBuilder = popupMenuBuilder {

--- a/sample/src/main/res/drawable/rounded_popup_background.xml
+++ b/sample/src/main/res/drawable/rounded_popup_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="8dp" />
+    <solid android:color="?colorBackgroundFloating" />
+</shape>

--- a/sample/src/main/res/layout/activity_dark.xml
+++ b/sample/src/main/res/layout/activity_dark.xml
@@ -108,13 +108,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
 
             <TextView
+                android:id="@+id/roundedCornersTextView"
+                style="@style/TitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/rounded_corners"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
+
+            <TextView
                 android:id="@+id/conditionalItemsTextView"
                 style="@style/TitleLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
+                app:layout_constraintTop_toBottomOf="@+id/roundedCornersTextView" />
 
             <TextView
                 android:id="@+id/conditionalItemsCopySubtitleTextView"

--- a/sample/src/main/res/layout/activity_light.xml
+++ b/sample/src/main/res/layout/activity_light.xml
@@ -108,13 +108,22 @@
                 app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
 
             <TextView
+                android:id="@+id/roundedCornersTextView"
+                style="@style/TitleLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/rounded_corners"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
+
+            <TextView
                 android:id="@+id/conditionalItemsTextView"
                 style="@style/TitleLabel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
                 app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
+                app:layout_constraintTop_toBottomOf="@+id/roundedCornersTextView" />
 
             <TextView
                 android:id="@+id/conditionalItemsCopySubtitleTextView"

--- a/sample/src/main/res/layout/view_custom_item_colored.xml
+++ b/sample/src/main/res/layout/view_custom_item_colored.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/colorPrimary"
+    android:clickable="true"
+    android:focusable="true"
+    android:paddingStart="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingTop="@dimen/mpm_popup_menu_vertical_padding"
+    android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingBottom="@dimen/mpm_popup_menu_vertical_padding"
+    android:text="@string/more"
+    android:textColor="@android:color/white" />
+

--- a/sample/src/main/res/values-v21/styles.xml
+++ b/sample/src/main/res/values-v21/styles.xml
@@ -4,4 +4,16 @@
         <item name="android:background">?android:selectableItemBackground</item>
     </style>
 
+    <style name="Widget.MPM.Menu.RoundedCorners">
+        <item name="mpm_paddingBottom">0dp</item>
+        <item name="mpm_paddingTop">0dp</item>
+        <item name="android:popupBackground">@drawable/rounded_popup_background</item>
+    </style>
+
+    <style name="Widget.MPM.Menu.Dark.RoundedCorners">
+        <item name="mpm_paddingBottom">0dp</item>
+        <item name="mpm_paddingTop">0dp</item>
+        <item name="android:popupBackground">@drawable/rounded_popup_background</item>
+    </style>
+
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -17,4 +17,5 @@
     <string name="copy">Copy</string>
     <string name="dimmed_background">Dimmed background</string>
     <string name="custom_padding">Custom padding</string>
+    <string name="rounded_corners">Rounded corners</string>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -77,11 +77,11 @@
     </style>
 
     <style name="Widget.MPM.Menu.RoundedCorners">
-        <item name="android:popupBackground">@drawable/rounded_popup_background</item>
+        <!-- See styles-v21 as background with rounded corners works since version 21 -->
     </style>
 
     <style name="Widget.MPM.Menu.Dark.RoundedCorners">
-        <item name="android:popupBackground">@drawable/rounded_popup_background</item>
+        <!-- See styles-v21 as background with rounded corners works since version 21 -->
     </style>
 
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -76,4 +76,12 @@
         <item name="mpm_paddingTop">16dp</item>
     </style>
 
+    <style name="Widget.MPM.Menu.RoundedCorners">
+        <item name="android:popupBackground">@drawable/rounded_popup_background</item>
+    </style>
+
+    <style name="Widget.MPM.Menu.Dark.RoundedCorners">
+        <item name="android:popupBackground">@drawable/rounded_popup_background</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
This change allows users to use custom items that have colored background and also use a popup with rounded corners.

Before the changes, the popup wouldn't display rounded corners for the custom view because its background wasn't clipped and it was drawing outside of the area of rounded drawable. After the change, when drawing, the content is properly clipped to the area of the background drawable and thus rounded corners work correctly.

___

I've also added sample for the rounded corners but unfortunately you can't see in it how I've fixed the corners issue. That's because the default view adds top and bottom padding which prevents the item from appearing at the edge of popup where the issue would be present. Although, that can be fixed if #44 gets merged so we can then set that vertical padding to 0.

Anyway here is how it looks right now:

<img src="https://user-images.githubusercontent.com/5156340/56097059-fc06a780-5eef-11e9-9ff6-4bf18192a0ce.png" height="580" />
