### PR TITLE
Fixes incorrect menu height in case of dynamic content

### DIFF
--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -287,7 +287,7 @@ class MaterialRecyclerViewPopupWindow(
     private fun measureHeightOfChildrenCompat(maxHeight: Int): Int {
 
         val parent = FrameLayout(contextThemeWrapper)
-        val widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+        val widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(dropDownWidth, View.MeasureSpec.EXACTLY)
 
         // Include the padding of the list
         var returnedHeight = 0
@@ -318,6 +318,9 @@ class MaterialRecyclerViewPopupWindow(
                 View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
             }
             itemView.measure(widthMeasureSpec, heightMeasureSpec)
+            // Since this view was measured directly against the parent measure
+            // spec, we must measure it again before reuse.
+            itemView.forceLayout()
 
             returnedHeight += itemView.measuredHeight
 

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -318,6 +318,7 @@ class DarkActivity : AppCompatActivity() {
         popupMenu.show(this@DarkActivity, view)
     }
 
+    @SuppressLint("SetTextI18n")
     @OnClick(R.id.customItemsTextView)
     fun onCustomItemsClicked(view: View) {
         val popupMenu = popupMenu {
@@ -343,6 +344,10 @@ class DarkActivity : AppCompatActivity() {
                 }
                 customItem {
                     layoutResId = R.layout.view_custom_item_large
+                    viewBoundCallback = { view ->
+                        val textView: TextView = view.findViewById(R.id.customItemTextView)
+                        textView.text = "Some long text that is applied later to see if height calculation indeed is incorrectly calculated due to this binding."
+                    }
                 }
             }
         }

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -1,5 +1,6 @@
 package com.github.zawadz88.materialpopupmenu.sample
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -297,6 +298,7 @@ class LightActivity : AppCompatActivity() {
         popupMenu.show(this@LightActivity, view)
     }
 
+    @SuppressLint("SetTextI18n")
     @OnClick(R.id.customItemsTextView)
     fun onCustomItemsClicked(view: View) {
         val popupMenu = popupMenu {
@@ -321,6 +323,10 @@ class LightActivity : AppCompatActivity() {
                 }
                 customItem {
                     layoutResId = R.layout.view_custom_item_large
+                    viewBoundCallback = { view ->
+                        val textView: TextView = view.findViewById(R.id.customItemTextView)
+                        textView.text = "Some long text that is applied later to see if height calculation indeed is incorrectly calculated due to this binding."
+                    }
                 }
             }
         }

--- a/sample/src/main/res/layout/view_custom_item_large.xml
+++ b/sample/src/main/res/layout/view_custom_item_large.xml
@@ -1,24 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.MPM.Item"
     android:layout_width="match_parent"
-    android:layout_height="96dp"
+    android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
     android:gravity="center"
-    android:orientation="horizontal"
-    android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:orientation="vertical"
     android:paddingStart="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
     tools:ignore="UseCompoundDrawables"
     tools:theme="@style/Widget.MPM.Menu">
+
+    <TextView
+        android:id="@+id/customItemTextView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        tools:text="Sample text" />
 
     <androidx.appcompat.widget.AppCompatImageView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:srcCompat="@mipmap/ic_launcher"/>
+        app:srcCompat="@mipmap/ic_launcher" />
 
 </LinearLayout>


### PR DESCRIPTION
Fixed incorrect item size if custom items contain a layout with `wrap_content` and dynamic content.

Fixes #49
Oreo:
![Screenshot_1555426557](https://user-images.githubusercontent.com/3322260/56220702-2c258600-6069-11e9-8880-e803f057c1e9.png)
KitKat:
![Screenshot_1555426565](https://user-images.githubusercontent.com/3322260/56220727-33e52a80-6069-11e9-8475-4ca6b0bbc02d.png)
