### PR TITLE
 Allow customizing default popup style via theme attribute 

### DIFF
--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -11,8 +11,6 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.PopupWindow
-import androidx.annotation.StyleRes
-import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.widget.PopupWindowCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -30,9 +28,8 @@ import java.lang.reflect.Method
  */
 @SuppressLint("PrivateResource,RestrictedApi")
 class MaterialRecyclerViewPopupWindow(
-    context: Context,
-    private var dropDownGravity: Int,
-    @StyleRes defStyleRes: Int
+    private val context: Context,
+    private var dropDownGravity: Int
 ) {
 
     companion object {
@@ -89,8 +86,6 @@ class MaterialRecyclerViewPopupWindow(
 
     private val popupWidthUnit: Int
 
-    private val contextThemeWrapper: Context
-
     private val windowManager: WindowManager by lazy {
         context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     }
@@ -108,18 +103,15 @@ class MaterialRecyclerViewPopupWindow(
     private val popupPaddingTop: Int
 
     init {
-        contextThemeWrapper = ContextThemeWrapper(context, null)
-        contextThemeWrapper.setTheme(defStyleRes)
-
-        popup = AppCompatPopupWindow(contextThemeWrapper, null, 0, defStyleRes)
+        popup = AppCompatPopupWindow(context, null, 0)
         popup.inputMethodMode = PopupWindow.INPUT_METHOD_NEEDED
         popup.isFocusable = true
 
-        popupMaxWidth = contextThemeWrapper.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_max_width)
-        popupMinWidth = contextThemeWrapper.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_min_width)
-        popupWidthUnit = contextThemeWrapper.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_width_unit)
+        popupMaxWidth = context.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_max_width)
+        popupMinWidth = context.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_min_width)
+        popupWidthUnit = context.resources.getDimensionPixelSize(R.dimen.mpm_popup_menu_width_unit)
 
-        val a = context.obtainStyledAttributes(null, R.styleable.MaterialRecyclerViewPopupWindow, 0, defStyleRes)
+        val a = context.obtainStyledAttributes(null, R.styleable.MaterialRecyclerViewPopupWindow)
 
         dropDownHorizontalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownHorizontalOffset, 0)
         dropDownVerticalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownVerticalOffset, 0)
@@ -219,9 +211,9 @@ class MaterialRecyclerViewPopupWindow(
     private fun buildDropDown(): Int {
         var otherHeights = 0
 
-        val dropDownList = View.inflate(contextThemeWrapper, R.layout.mpm_popup_menu, null) as RecyclerView
+        val dropDownList = View.inflate(context, R.layout.mpm_popup_menu, null) as RecyclerView
         dropDownList.adapter = adapter
-        dropDownList.layoutManager = LinearLayoutManager(this.contextThemeWrapper)
+        dropDownList.layoutManager = LinearLayoutManager(context)
         dropDownList.isFocusable = true
         dropDownList.isFocusableInTouchMode = true
         dropDownList.setPadding(popupPaddingLeft, popupPaddingTop, popupPaddingRight, popupPaddingBottom)
@@ -286,7 +278,7 @@ class MaterialRecyclerViewPopupWindow(
      */
     private fun measureHeightOfChildrenCompat(maxHeight: Int): Int {
 
-        val parent = FrameLayout(contextThemeWrapper)
+        val parent = FrameLayout(context)
         val widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(dropDownWidth, View.MeasureSpec.EXACTLY)
 
         // Include the padding of the list
@@ -372,7 +364,7 @@ class MaterialRecyclerViewPopupWindow(
      */
     private fun measureIndividualMenuWidth(adapter: PopupMenuAdapter): Int {
         adapter.setupIndices()
-        val parent = FrameLayout(contextThemeWrapper)
+        val parent = FrameLayout(context)
         var menuWidth = popupMinWidth
 
         val widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -9,6 +9,7 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.annotation.UiThread
+import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.MaterialRecyclerViewPopupWindow
 import com.github.zawadz88.materialpopupmenu.internal.PopupMenuAdapter
 
@@ -41,8 +42,9 @@ class MaterialPopupMenu internal constructor(
     @UiThread
     fun show(context: Context, anchor: View) {
         val style = resolvePopupStyle(context)
-        val popupWindow = MaterialRecyclerViewPopupWindow(context, dropdownGravity, style)
-        val adapter = PopupMenuAdapter(context, style, sections) { popupWindow.dismiss() }
+        val styledContext = ContextThemeWrapper(context, style)
+        val popupWindow = MaterialRecyclerViewPopupWindow(styledContext, dropdownGravity)
+        val adapter = PopupMenuAdapter(sections) { popupWindow.dismiss() }
 
         popupWindow.adapter = adapter
         popupWindow.anchorView = anchor

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -22,7 +22,7 @@ import com.github.zawadz88.materialpopupmenu.internal.PopupMenuAdapter
  * @author Piotr Zawadzki
  */
 class MaterialPopupMenu internal constructor(
-    @StyleRes internal val style: Int,
+    @StyleRes internal val style: Int?,
     internal val dropdownGravity: Int,
     internal val sections: List<PopupMenuSection>
 ) {
@@ -40,6 +40,7 @@ class MaterialPopupMenu internal constructor(
      */
     @UiThread
     fun show(context: Context, anchor: View) {
+        val style = resolvePopupStyle(context)
         val popupWindow = MaterialRecyclerViewPopupWindow(context, dropdownGravity, style)
         val adapter = PopupMenuAdapter(context, style, sections) { popupWindow.dismiss() }
 
@@ -67,6 +68,18 @@ class MaterialPopupMenu internal constructor(
     fun setOnDismissListener(listener: (() -> Unit)?) {
         this.dismissListener = listener
         this.popupWindow?.setOnDismissListener(listener)
+    }
+
+    private fun resolvePopupStyle(context: Context): Int {
+        if (style != null) {
+            return style
+        }
+
+        val a = context.obtainStyledAttributes(intArrayOf(R.attr.materialPopupMenuStyle))
+        val resolvedStyle = a.getResourceId(0, R.style.Widget_MPM_Menu)
+        a.recycle()
+
+        return resolvedStyle
     }
 
     internal data class PopupMenuSection(

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -23,7 +23,7 @@ import com.github.zawadz88.materialpopupmenu.internal.PopupMenuAdapter
  * @author Piotr Zawadzki
  */
 class MaterialPopupMenu internal constructor(
-    @StyleRes internal val style: Int?,
+    @StyleRes internal val style: Int,
     internal val dropdownGravity: Int,
     internal val sections: List<PopupMenuSection>
 ) {
@@ -73,7 +73,7 @@ class MaterialPopupMenu internal constructor(
     }
 
     private fun resolvePopupStyle(context: Context): Int {
-        if (style != null) {
+        if (style != 0) {
             return style
         }
 

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -20,14 +20,18 @@ import androidx.annotation.StringRes
 class MaterialPopupMenuBuilder {
 
     /**
-     * Style of the popup menu. Default is [R.style.Widget_MPM_Menu].
+     * Style of the popup menu.
      *
      * For dark themes you should use [R.style.Widget_MPM_Menu_Dark].
      *
-     * You can also provide your own style, however make sure that all of the attributes
-     * that are declared in [R.style.Widget_MPM_Menu] are also declared in your style.
+     * Setting this to `null` will make the popup use the default style resolved based on context
+     * passed to [MaterialPopupMenu.show] function. You can customize that default style by defining
+     * [R.attr.materialPopupMenuStyle] in your theme style.
+     *
+     * *NOTE:* make sure that all of the attributes that are declared in [R.style.Widget_MPM_Menu]
+     * are also declared in your style.
      */
-    var style: Int = R.style.Widget_MPM_Menu
+    var style: Int? = null
 
     /**
      * Gravity of the dropdown list. This is commonly used to

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -24,14 +24,14 @@ class MaterialPopupMenuBuilder {
      *
      * For dark themes you should use [R.style.Widget_MPM_Menu_Dark].
      *
-     * Setting this to `null` will make the popup use the default style resolved based on context
+     * Setting this to `0` will make the popup use the default style resolved based on context
      * passed to [MaterialPopupMenu.show] function. You can customize that default style by defining
      * [R.attr.materialPopupMenuStyle] in your theme style.
      *
      * *NOTE:* make sure that all of the attributes that are declared in [R.style.Widget_MPM_Menu]
      * are also declared in your style.
      */
-    var style: Int? = null
+    var style: Int = 0
 
     /**
      * Gravity of the dropdown list. This is commonly used to

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
@@ -1,14 +1,11 @@
 package com.github.zawadz88.materialpopupmenu.internal
 
 import android.annotation.SuppressLint
-import android.content.Context
 import android.content.res.ColorStateList
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
-import androidx.annotation.StyleRes
-import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.recyclerview.widget.RecyclerView
 import com.github.zawadz88.materialpopupmenu.MaterialPopupMenu
@@ -21,18 +18,13 @@ import com.github.zawadz88.materialpopupmenu.R
  */
 @SuppressLint("RestrictedApi")
 internal class PopupMenuAdapter(
-        context: Context,
-        @StyleRes style: Int,
-        private val sections: List<MaterialPopupMenu.PopupMenuSection>,
-        private val onItemClickedCallback: (MaterialPopupMenu.AbstractPopupMenuItem) -> Unit)
+    private val sections: List<MaterialPopupMenu.PopupMenuSection>,
+    private val onItemClickedCallback: (MaterialPopupMenu.AbstractPopupMenuItem) -> Unit
+)
     : SectionedRecyclerViewAdapter<PopupMenuAdapter.SectionHeaderViewHolder, PopupMenuAdapter.AbstractItemViewHolder>() {
-
-    private val contextThemeWrapper: ContextThemeWrapper
 
     init {
         setHasStableIds(false)
-        contextThemeWrapper = ContextThemeWrapper(context, null)
-        contextThemeWrapper.setTheme(style)
     }
 
     override fun getItemCountForSection(section: Int): Int {
@@ -43,7 +35,7 @@ internal class PopupMenuAdapter(
         get() = sections.size
 
     override fun onCreateSectionHeaderViewHolder(parent: ViewGroup, viewType: Int): SectionHeaderViewHolder {
-        val v = LayoutInflater.from(contextThemeWrapper).inflate(R.layout.mpm_popup_menu_section_header, parent, false)
+        val v = LayoutInflater.from(parent.context).inflate(R.layout.mpm_popup_menu_section_header, parent, false)
         return SectionHeaderViewHolder(v)
     }
 
@@ -57,10 +49,10 @@ internal class PopupMenuAdapter(
 
     override fun onCreateItemViewHolder(parent: ViewGroup, viewType: Int): AbstractItemViewHolder {
         return if (viewType == TYPE_ITEM) {
-            val v = LayoutInflater.from(contextThemeWrapper).inflate(R.layout.mpm_popup_menu_item, parent, false)
+            val v = LayoutInflater.from(parent.context).inflate(R.layout.mpm_popup_menu_item, parent, false)
             ItemViewHolder(v)
         } else {
-            val v = LayoutInflater.from(contextThemeWrapper).inflate(viewType, parent, false)
+            val v = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
             CustomItemViewHolder(v)
         }
     }

--- a/material-popup-menu/src/main/res/values/attrs.xml
+++ b/material-popup-menu/src/main/res/values/attrs.xml
@@ -17,6 +17,8 @@
 
     <attr name="mpm_paddingTop" format="dimension" />
 
+    <attr name="materialPopupMenuStyle" format="reference" />
+
     <declare-styleable name="MaterialRecyclerViewPopupWindow">
         <attr name="android:dropDownHorizontalOffset" />
         <attr name="android:dropDownVerticalOffset" />

--- a/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
+++ b/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
@@ -97,7 +97,7 @@ class MaterialPopupMenuBuilderTest {
 
         //then
         assertEquals("Invalid dropdown gravity", Gravity.NO_GRAVITY, popupMenu.dropdownGravity)
-        assertNull("Invalid popup style", popupMenu.style)
+        assertEquals("Invalid popup style", 0, popupMenu.style)
         assertThat("Should contain a single section", popupMenu.sections, hasSize(1))
         val (title, items) = popupMenu.sections[0]
         assertNull("Section title should be null", title)

--- a/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
+++ b/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
@@ -97,7 +97,7 @@ class MaterialPopupMenuBuilderTest {
 
         //then
         assertEquals("Invalid dropdown gravity", Gravity.NO_GRAVITY, popupMenu.dropdownGravity)
-        assertEquals("Invalid popup style", R.style.Widget_MPM_Menu, popupMenu.style)
+        assertNull("Invalid popup style", popupMenu.style)
         assertThat("Should contain a single section", popupMenu.sections, hasSize(1))
         val (title, items) = popupMenu.sections[0]
         assertNull("Section title should be null", title)


### PR DESCRIPTION
This pull request adds `materialPopupStyle` attribute which allows customizing the default style that will be used by all of the popups created by this library (unless overridden in the builder via `style` property)

# Example

![2019-04-16_18-37-44](https://user-images.githubusercontent.com/5156340/56228080-3c446200-6077-11e9-8dc5-c30cd39a063a.gif)

Here I've applied the below change. Notice how all of the popups except for these that define custom style have changed to that dark style with dimmed background.

```diff
diff --git a/sample/src/main/res/values/styles.xml b/sample/src/main/res/values/styles.xml
index a7db238572786f68142759156494a2229cc7e331..85c90ef297367cb01a3d015365322964d579e1eb 100644
--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -13,6 +13,7 @@
         <item name="colorPrimary">@color/lightColorPrimary</item>
         <item name="colorPrimaryDark">@color/lightColorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="materialPopupMenuStyle">@style/Widget.MPM.Menu.Dark.Dimmed</item>
     </style>
 
     <style name="AppTheme.Dark" parent="Theme.AppCompat.NoActionBar">
```

___
## Additional change

I've also cleaned a bit usage of `ContextThemeWrapper`. Now it's created only once and passed to `MaterialRecyclerViewPopupWindow` directly as a `Context`. Also I've removed the context from `PopupMenuAdapter` and instead made all views inherit from their parent view context which in turn makes them use the context from `MaterialRecyclerViewPopupWindow`. (Unless I'm somehow mistaken 😏). You can ignore that second commit if you don't want that change. It shouldn't affect the topic of this pull request but I found it related enough to keep here.