### PR TITLE
Disable clipToPadding on menu RecyclerView

### DIFF
--- a/material-popup-menu/src/main/res/layout/mpm_popup_menu.xml
+++ b/material-popup-menu/src/main/res/layout/mpm_popup_menu.xml
@@ -2,4 +2,5 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:clipToPadding="false"
     tools:listitem="@layout/mpm_popup_menu_item" />


### PR DESCRIPTION
This change makes it so the popup content isn't clipped to the padding when scrolled.

| Before | After |
| ------ | ------ |
| ![Screenshot_1555436905](https://user-images.githubusercontent.com/5156340/56232395-eaa0d500-6080-11e9-96ce-95cbc661b6b9.png) | ![Screenshot_1555436887](https://user-images.githubusercontent.com/5156340/56232394-eaa0d500-6080-11e9-98c3-abf90935a8cd.png) |
