### PR TITLE
Take margins under account when calculating popup height

### DIFF
--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -322,7 +322,12 @@ class MaterialRecyclerViewPopupWindow(
             // spec, we must measure it again before reuse.
             itemView.forceLayout()
 
-            returnedHeight += itemView.measuredHeight
+            val marginLayoutParams = childLp as? ViewGroup.MarginLayoutParams
+            val topMargin = marginLayoutParams?.topMargin ?: 0
+            val bottomMargin = marginLayoutParams?.bottomMargin ?: 0
+            val verticalMargin = topMargin + bottomMargin
+
+            returnedHeight += itemView.measuredHeight + verticalMargin
 
             if (returnedHeight >= maxHeight) {
                 // We went over, figure out which height to return.  If returnedHeight >


### PR DESCRIPTION
See https://github.com/zawadz88/MaterialPopupMenu/issues/49#issuecomment-483780663

This change updates height calculation for popup to also look at vertical margin of each item.