### PR TITLE
Make it possible to dismiss popup from viewBoundCallback

### DIFF
--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -102,7 +102,7 @@ class MaterialPopupMenu internal constructor(
 
     internal data class PopupMenuCustomItem(
         @LayoutRes val layoutResId: Int,
-        val viewBoundCallback: (View) -> Unit,
+        val viewBoundCallback: ViewBoundCallback,
         override val callback: () -> Unit,
         override val dismissOnSelect: Boolean
     ) : AbstractPopupMenuItem(callback, dismissOnSelect)

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -218,6 +218,11 @@ class MaterialPopupMenuBuilder {
         /**
          * Callback to be invoked once the custom item view gets created and bound.
          * It is to be used when some views inside need to be updated once inflated.
+         *
+         * You can set this to [ViewBoundCallback] to gain access to additional
+         * features.
+         *
+         * @see ViewBoundCallback
          */
         var viewBoundCallback: (View) -> Unit = {}
 
@@ -227,9 +232,11 @@ class MaterialPopupMenuBuilder {
 
         override fun convertToPopupMenuItem(): MaterialPopupMenu.PopupMenuCustomItem {
             require(layoutResId != 0) { "Layout resource ID must be set for a custom item!" }
+            val resolvedViewBoundCallback = viewBoundCallback as? ViewBoundCallback
+                ?: ViewBoundCallback { viewBoundCallback(it) }
             return MaterialPopupMenu.PopupMenuCustomItem(
                     layoutResId = layoutResId,
-                    viewBoundCallback = viewBoundCallback,
+                    viewBoundCallback = resolvedViewBoundCallback,
                     callback = callback,
                     dismissOnSelect = dismissOnSelect)
         }

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/ViewBoundCallback.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/ViewBoundCallback.kt
@@ -1,0 +1,31 @@
+package com.github.zawadz88.materialpopupmenu
+
+import android.view.View
+
+/**
+ * Callback to be invoked once the custom item view gets created and bound.
+ * It is to be used when some views inside need to be updated once inflated.
+ *
+ * This class is an extension for closure based callback that provides
+ * additional functionality such as dismissing popup.
+ *
+ * @param callback block of the callback in which you can bind the given view
+ */
+class ViewBoundCallback(
+    private val callback: ViewBoundCallback.(View) -> Unit
+) : (View) -> Unit {
+    internal var dismissPopupAction: () -> Unit = {
+        throw IllegalStateException("Dismiss popup action has not been initialized. Make sure that you invoke dismissPopup function only after the popup has been shown.")
+    }
+
+    /**
+     * Dismisses the shown popup.
+     */
+    fun dismissPopup() {
+        dismissPopupAction()
+    }
+
+    override fun invoke(view: View) {
+        callback(view)
+    }
+}

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
@@ -19,7 +19,7 @@ import com.github.zawadz88.materialpopupmenu.R
 @SuppressLint("RestrictedApi")
 internal class PopupMenuAdapter(
     private val sections: List<MaterialPopupMenu.PopupMenuSection>,
-    private val onItemClickedCallback: (MaterialPopupMenu.AbstractPopupMenuItem) -> Unit
+    private val dismissPopupCallback: () -> Unit
 )
     : SectionedRecyclerViewAdapter<PopupMenuAdapter.SectionHeaderViewHolder, PopupMenuAdapter.AbstractItemViewHolder>() {
 
@@ -53,7 +53,7 @@ internal class PopupMenuAdapter(
             ItemViewHolder(v)
         } else {
             val v = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
-            CustomItemViewHolder(v)
+            CustomItemViewHolder(v, dismissPopupCallback)
         }
     }
 
@@ -75,7 +75,7 @@ internal class PopupMenuAdapter(
         holder.itemView.setOnClickListener {
             popupMenuItem.callback()
             if (popupMenuItem.dismissOnSelect) {
-                onItemClickedCallback(popupMenuItem)
+                dismissPopupCallback()
             }
         }
     }
@@ -117,10 +117,14 @@ internal class PopupMenuAdapter(
 
     }
 
-    internal class CustomItemViewHolder(itemView: View) : AbstractItemViewHolder(itemView) {
+    internal class CustomItemViewHolder(
+        itemView: View,
+        private val dismissPopupCallback: () -> Unit
+    ) : AbstractItemViewHolder(itemView) {
 
         override fun bindItem(popupMenuItem: MaterialPopupMenu.AbstractPopupMenuItem) {
             val popupMenuCustomItem = popupMenuItem as MaterialPopupMenu.PopupMenuCustomItem
+            popupMenuCustomItem.viewBoundCallback.dismissPopupAction = dismissPopupCallback
             popupMenuCustomItem.viewBoundCallback.invoke(itemView)
         }
     }

--- a/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
+++ b/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
@@ -242,10 +242,8 @@ class MaterialPopupMenuBuilderTest {
     @Test
     fun `Should build a popup menu with multiple custom items`() {
         //given
-        val view = mock<View> {}
-        var callbackInvoked = false
         val customCallback = {}
-        val customViewBoundCallback: (View) -> Unit = { callbackInvoked = true }
+        val customViewBoundCallback: (View) -> Unit = {}
 
         //when
         val popupMenu = popupMenu {
@@ -277,8 +275,29 @@ class MaterialPopupMenuBuilderTest {
         val secondPopupMenuItem = secondItem as MaterialPopupMenu.PopupMenuCustomItem
         assertEquals("Invalid item layout ID", CUSTOM_ITEM_LAYOUT, secondPopupMenuItem.layoutResId)
         assertEquals("Invalid item callback", customCallback, secondPopupMenuItem.callback)
+    }
 
-        secondPopupMenuItem.viewBoundCallback.invoke(view)
+    @Test
+    fun `Should invoke custom view bound callback`() {
+        //given
+        val view = mock<View> {}
+        var callbackInvoked = false
+        val customViewBoundCallback: (View) -> Unit = { callbackInvoked = true }
+        val popupMenu = popupMenu {
+            section {
+                customItem {
+                    layoutResId = CUSTOM_ITEM_LAYOUT
+                    viewBoundCallback = customViewBoundCallback
+                }
+            }
+        }
+
+        //when
+        val item = popupMenu.sections[0].items[0]
+        val popupMenuItem = item as MaterialPopupMenu.PopupMenuCustomItem
+        popupMenuItem.viewBoundCallback.invoke(view)
+
+        //then
         assertTrue("View bound callback has not beed invoked", callbackInvoked)
     }
 

--- a/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
+++ b/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
@@ -9,6 +9,7 @@ import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -241,8 +242,10 @@ class MaterialPopupMenuBuilderTest {
     @Test
     fun `Should build a popup menu with multiple custom items`() {
         //given
+        val view = mock<View> {}
+        var callbackInvoked = false
         val customCallback = {}
-        val customViewBoundCallback: (View) -> Unit = {}
+        val customViewBoundCallback: (View) -> Unit = { callbackInvoked = true }
 
         //when
         val popupMenu = popupMenu {
@@ -274,7 +277,9 @@ class MaterialPopupMenuBuilderTest {
         val secondPopupMenuItem = secondItem as MaterialPopupMenu.PopupMenuCustomItem
         assertEquals("Invalid item layout ID", CUSTOM_ITEM_LAYOUT, secondPopupMenuItem.layoutResId)
         assertEquals("Invalid item callback", customCallback, secondPopupMenuItem.callback)
-        assertEquals("Invalid item view bound callback", customViewBoundCallback, secondPopupMenuItem.viewBoundCallback)
+
+        secondPopupMenuItem.viewBoundCallback.invoke(view)
+        assertTrue("View bound callback has not beed invoked", callbackInvoked)
     }
 
     @Test

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -20,6 +20,7 @@ import android.widget.Toast
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
+import com.github.zawadz88.materialpopupmenu.ViewBoundCallback
 import com.github.zawadz88.materialpopupmenu.popupMenu
 import com.github.zawadz88.materialpopupmenu.popupMenuBuilder
 
@@ -334,9 +335,14 @@ class DarkActivity : AppCompatActivity() {
                 }
                 customItem {
                     layoutResId = R.layout.view_custom_item_checkable
-                    viewBoundCallback = { view ->
+                    viewBoundCallback = ViewBoundCallback { view ->
                         val checkBox: CheckBox = view.findViewById(R.id.customItemCheckbox)
                         checkBox.isChecked = true
+                        checkBox.setOnCheckedChangeListener { _, isChecked ->
+                            if (isChecked) {
+                                dismissPopup()
+                            }
+                        }
                     }
                     callback = {
                         Toast.makeText(this@DarkActivity, "Disabled!", Toast.LENGTH_SHORT).show()

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -20,6 +20,7 @@ import androidx.core.content.ContextCompat
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
+import com.github.zawadz88.materialpopupmenu.ViewBoundCallback
 import com.github.zawadz88.materialpopupmenu.popupMenu
 import com.github.zawadz88.materialpopupmenu.popupMenuBuilder
 
@@ -313,9 +314,14 @@ class LightActivity : AppCompatActivity() {
                 }
                 customItem {
                     layoutResId = R.layout.view_custom_item_checkable
-                    viewBoundCallback = { view ->
+                    viewBoundCallback = ViewBoundCallback { view ->
                         val checkBox: CheckBox = view.findViewById(R.id.customItemCheckbox)
                         checkBox.isChecked = true
+                        checkBox.setOnCheckedChangeListener { _, isChecked ->
+                            if (isChecked) {
+                                dismissPopup()
+                            }
+                        }
                     }
                     callback = {
                         Toast.makeText(this@LightActivity, "Disabled!", Toast.LENGTH_SHORT).show()

--- a/sample/src/main/res/layout/view_custom_item_checkable.xml
+++ b/sample/src/main/res/layout/view_custom_item_checkable.xml
@@ -29,8 +29,6 @@
         android:id="@+id/customItemCheckbox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@null"
-        android:clickable="false"
-        android:focusable="false" />
+        android:background="@null" />
 
 </LinearLayout>


### PR DESCRIPTION
# Use case
I want to be able to dismiss popup when user performs action on a custom item's view.

# Current solution
Impossible?

# Implemented solution
When building custom item it is now possible to set `viewBoundCallback` to an instance of `ViewBoundCallback` class instead of a regular closure, which then allows user to access `dismissPopup` function.

```kt
section {
  item {
    viewBoundCallback = ViewBoundCallback {
      val someView = it.findViewById(R.id.some_view)
      someView.setOnClickListener {
        dismissPopup()
      }
    }
  }
}
```

# Sample
<img src="https://user-images.githubusercontent.com/5156340/56849195-c3080300-68f1-11e9-835f-9163e7499c04.gif" height="580" />

_Here sample has been modified to dismiss the popup when only when checkbox gets checked._
