### PR TITLE
Release/4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [4.0.0]
+### Changed
+- Moved `super.bindItem` call to the end of `ItemViewHolder#bindItem`method so that it's possible to override values set by it in callbacks.
+- *Breaking change:* updated `MaterialPopupMenuBuilder.SectionHolder.label` and `MaterialPopupMenuBuilder.ItemHolder.label` to be of type `CharSequence` rather than `String` to allow the use of `Spannables`.
+
 ## [3.4.0]
 ### Added
 - An option to display an icon at the end of each item which indicates a nested submenu.
@@ -98,7 +103,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 Initial release of the library.
 
-[Unreleased]: https://github.com/zawadz88/MaterialPopupMenu/compare/3.4.0...HEAD
+[Unreleased]: https://github.com/zawadz88/MaterialPopupMenu/compare/4.0.0...HEAD
+[4.0.0]: https://github.com/zawadz88/MaterialPopupMenu/compare/3.4.0...4.0.0
 [3.4.0]: https://github.com/zawadz88/MaterialPopupMenu/compare/3.3.0...3.4.0
 [3.3.0]: https://github.com/zawadz88/MaterialPopupMenu/compare/3.2.0...3.3.0
 [3.2.0]: https://github.com/zawadz88/MaterialPopupMenu/compare/3.1.0...3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [4.0.0]
 ### Changed
 - *Breaking change:* minimum SDK version raised to API 19 (Kitkat)
-- Moved `super.bindItem` call to the end of `ItemViewHolder#bindItem`method so that it's possible to override values set by it in callbacks.
+- *Breaking change:* replaced `mpm_paddingLeft` with `mpm_paddingStart` and `mpm_paddingRight` with `mpm_paddingEnd` and other inter layout attributes accordingly for better RTL support
 - *Breaking change:* updated `MaterialPopupMenuBuilder.SectionHolder.label` and `MaterialPopupMenuBuilder.ItemHolder.label` to be of type `CharSequence` rather than `String` to allow the use of `Spannables`.
+- Moved `super.bindItem` call to the end of `ItemViewHolder#bindItem`method so that it's possible to override values set by it in callbacks.
 
 ### Added
 - an option to override the defaults and set menu width & dropdown offsets programmatically via `MaterialPopupMenuBuilder`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [4.0.0]
 ### Changed
+- *Breaking change:* minimum SDK version raised to API 19 (Kitkat)
 - Moved `super.bindItem` call to the end of `ItemViewHolder#bindItem`method so that it's possible to override values set by it in callbacks.
 - *Breaking change:* updated `MaterialPopupMenuBuilder.SectionHolder.label` and `MaterialPopupMenuBuilder.ItemHolder.label` to be of type `CharSequence` rather than `String` to allow the use of `Spannables`.
+
+### Added
+- an option to override the defaults and set menu width & dropdown offsets programmatically via `MaterialPopupMenuBuilder`
 
 ## [3.4.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To create a popup menu with 2 sections and a section title in the second one:
 * Adding additional offsets to where the dialog should be shown
 * Keeping popup open after clicking on item
 * Dimming background behind popup
-* Customizing popup padding
+* Customizing popup width, padding & offsets
 * Displaying an icon at the end of each item which indicates a nested submenu
 
 ## Custom views
@@ -201,3 +201,6 @@ Check out the [official documentation](https://kotlinlang.org/docs/reference/bas
 
 ### I have not migrated to AndroidX. Can I use this library?
 If you're still using legacy Android Support libraries you can use version 2.2.0. AndroidX is supported by default since 3.0.0.
+
+### Can I use this library on Jelly Bean?
+Up to 3.4.0 minimum supported version was API 16 (Jelly Bean) so you can use that version. Since 4.0.0 minimum supported version is API 19 (Kitkat).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library allows to create simple popup menus programmatically with a nice [t
 
 ## Download (from JCenter)
 ```groovy
-implementation 'com.github.zawadz88.materialpopupmenu:material-popup-menu:3.4.0'
+implementation 'com.github.zawadz88.materialpopupmenu:material-popup-menu:4.0.0'
 ```
 
 ## Getting started
@@ -201,7 +201,3 @@ Check out the [official documentation](https://kotlinlang.org/docs/reference/bas
 
 ### I have not migrated to AndroidX. Can I use this library?
 If you're still using legacy Android Support libraries you can use version 2.2.0. AndroidX is supported by default since 3.0.0.
-
-## TODOs:
-* add Espresso tests
-* add item selection

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ allprojects {
 
 configure(allprojects) {
     ext {
-        ANDROID_MIN_SDK_VERSION             = 16
+        ANDROID_MIN_SDK_VERSION             = 19
         ANDROID_TARGET_SDK_VERSION          = 28
         ANDROID_COMPILE_SDK_VERSION         = 28
         ANDROID_BUILD_TOOLS_VERSION         = '28.0.3'

--- a/docs/material-popup-menu/alltypes/index.html
+++ b/docs/material-popup-menu/alltypes/index.html
@@ -24,13 +24,6 @@
 </tr>
 <tr>
 <td>
-<a href="../androidx.appcompat.widget/-material-recycler-view-popup-window/index.html">androidx.appcompat.widget.MaterialRecyclerViewPopupWindow</a></td>
-<td>
-<p>A more Material version of <a href="#">ListPopupWindow</a> based on <a href="#">RecyclerView</a>.</p>
-</td>
-</tr>
-<tr>
-<td>
 <a href="../com.github.zawadz88.materialpopupmenu.internal/-sectioned-recycler-view-adapter/index.html">com.github.zawadz88.materialpopupmenu.internal.SectionedRecyclerViewAdapter</a></td>
 <td>
 <p>An extension to RecyclerView.Adapter to provide sections with headers to a

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-item-holder/index.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-item-holder/index.html
@@ -69,7 +69,7 @@
 <p><a href="label.html">label</a></p>
 </td>
 <td>
-<code><span class="keyword">var </span><span class="identifier">label</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">?</span></code>
+<code><span class="keyword">var </span><span class="identifier">label</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-sequence/index.html"><span class="identifier">CharSequence</span></a><span class="symbol">?</span></code>
 <p>Item label.</p>
 </td>
 </tr>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-item-holder/label.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-item-holder/label.html
@@ -9,7 +9,7 @@
 <br/>
 <h1>label</h1>
 <a name="com.github.zawadz88.materialpopupmenu.MaterialPopupMenuBuilder.ItemHolder$label"></a>
-<code><span class="keyword">var </span><span class="identifier">label</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">?</span></code>
+<code><span class="keyword">var </span><span class="identifier">label</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-sequence/index.html"><span class="identifier">CharSequence</span></a><span class="symbol">?</span></code>
 <p>Item label.</p>
 <p>This is a required field and must not be <em>null</em>, unless you specify a label
 using <a href="label-res.html">labelRes</a>.</p>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-section-holder/index.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-section-holder/index.html
@@ -32,7 +32,7 @@
 <p><a href="title.html">title</a></p>
 </td>
 <td>
-<code><span class="keyword">var </span><span class="identifier">title</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">?</span></code>
+<code><span class="keyword">var </span><span class="identifier">title</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-sequence/index.html"><span class="identifier">CharSequence</span></a><span class="symbol">?</span></code>
 <p>Optional section holder. <em>null</em> by default.
 If the title is not <em>null</em> it will be displayed in the menu.</p>
 </td>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-section-holder/title.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/-section-holder/title.html
@@ -9,7 +9,7 @@
 <br/>
 <h1>title</h1>
 <a name="com.github.zawadz88.materialpopupmenu.MaterialPopupMenuBuilder.SectionHolder$title"></a>
-<code><span class="keyword">var </span><span class="identifier">title</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html"><span class="identifier">String</span></a><span class="symbol">?</span></code>
+<code><span class="keyword">var </span><span class="identifier">title</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-char-sequence/index.html"><span class="identifier">CharSequence</span></a><span class="symbol">?</span></code>
 <p>Optional section holder. <em>null</em> by default.
 If the title is not <em>null</em> it will be displayed in the menu.</p>
 </BODY>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/drop-down-horizontal-offset.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/drop-down-horizontal-offset.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>MaterialPopupMenuBuilder.dropDownHorizontalOffset - material-popup-menu</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">material-popup-menu</a>&nbsp;/&nbsp;<a href="../index.html">com.github.zawadz88.materialpopupmenu</a>&nbsp;/&nbsp;<a href="index.html">MaterialPopupMenuBuilder</a>&nbsp;/&nbsp;<a href="./drop-down-horizontal-offset.html">dropDownHorizontalOffset</a><br/>
+<br/>
+<h1>dropDownHorizontalOffset</h1>
+<a name="com.github.zawadz88.materialpopupmenu.MaterialPopupMenuBuilder$dropDownHorizontalOffset"></a>
+<code><span class="keyword">var </span><span class="identifier">dropDownHorizontalOffset</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a><span class="symbol">?</span></code>
+<p>Setting this to non-<code>null</code> value will override <code>android:dropDownHorizontalOffset</code> set by the style applied in <a href="style.html">style</a>.</p>
+</BODY>
+</HTML>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/drop-down-vertical-offset.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/drop-down-vertical-offset.html
@@ -1,0 +1,15 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>MaterialPopupMenuBuilder.dropDownVerticalOffset - material-popup-menu</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">material-popup-menu</a>&nbsp;/&nbsp;<a href="../index.html">com.github.zawadz88.materialpopupmenu</a>&nbsp;/&nbsp;<a href="index.html">MaterialPopupMenuBuilder</a>&nbsp;/&nbsp;<a href="./drop-down-vertical-offset.html">dropDownVerticalOffset</a><br/>
+<br/>
+<h1>dropDownVerticalOffset</h1>
+<a name="com.github.zawadz88.materialpopupmenu.MaterialPopupMenuBuilder$dropDownVerticalOffset"></a>
+<code><span class="keyword">var </span><span class="identifier">dropDownVerticalOffset</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a><span class="symbol">?</span></code>
+<p>Setting this to non-<code>null</code> value will override <code>android:dropDownVerticalOffset</code> set by the style applied in <a href="style.html">style</a>.</p>
+</BODY>
+</HTML>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/fixed-content-width-in-px.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/fixed-content-width-in-px.html
@@ -1,0 +1,16 @@
+<HTML>
+<HEAD>
+<meta charset="UTF-8">
+<title>MaterialPopupMenuBuilder.fixedContentWidthInPx - material-popup-menu</title>
+<link rel="stylesheet" href="../../../style.css">
+</HEAD>
+<BODY>
+<a href="../../index.html">material-popup-menu</a>&nbsp;/&nbsp;<a href="../index.html">com.github.zawadz88.materialpopupmenu</a>&nbsp;/&nbsp;<a href="index.html">MaterialPopupMenuBuilder</a>&nbsp;/&nbsp;<a href="./fixed-content-width-in-px.html">fixedContentWidthInPx</a><br/>
+<br/>
+<h1>fixedContentWidthInPx</h1>
+<a name="com.github.zawadz88.materialpopupmenu.MaterialPopupMenuBuilder$fixedContentWidthInPx"></a>
+<code><span class="keyword">var </span><span class="identifier">fixedContentWidthInPx</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a></code>
+<p>Setting this to a non-zero value will force the width of the popup menu to be exactly this value.
+If set to 0, the default mechanism for measuring popup menu width will be applied.</p>
+</BODY>
+</HTML>

--- a/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/index.html
+++ b/docs/material-popup-menu/com.github.zawadz88.materialpopupmenu/-material-popup-menu-builder/index.html
@@ -83,6 +83,34 @@ Setting <a href="https://developer.android.com/reference/android/view/Gravity.ht
 </tr>
 <tr>
 <td>
+<p><a href="drop-down-horizontal-offset.html">dropDownHorizontalOffset</a></p>
+</td>
+<td>
+<code><span class="keyword">var </span><span class="identifier">dropDownHorizontalOffset</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a><span class="symbol">?</span></code>
+<p>Setting this to non-<code>null</code> value will override <code>android:dropDownHorizontalOffset</code> set by the style applied in <a href="style.html">style</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="drop-down-vertical-offset.html">dropDownVerticalOffset</a></p>
+</td>
+<td>
+<code><span class="keyword">var </span><span class="identifier">dropDownVerticalOffset</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a><span class="symbol">?</span></code>
+<p>Setting this to non-<code>null</code> value will override <code>android:dropDownVerticalOffset</code> set by the style applied in <a href="style.html">style</a>.</p>
+</td>
+</tr>
+<tr>
+<td>
+<p><a href="fixed-content-width-in-px.html">fixedContentWidthInPx</a></p>
+</td>
+<td>
+<code><span class="keyword">var </span><span class="identifier">fixedContentWidthInPx</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html"><span class="identifier">Int</span></a></code>
+<p>Setting this to a non-zero value will force the width of the popup menu to be exactly this value.
+If set to 0, the default mechanism for measuring popup menu width will be applied.</p>
+</td>
+</tr>
+<tr>
+<td>
 <p><a href="style.html">style</a></p>
 </td>
 <td>

--- a/docs/material-popup-menu/index.html
+++ b/docs/material-popup-menu/index.html
@@ -12,13 +12,6 @@
 <tbody>
 <tr>
 <td>
-<p><a href="androidx.appcompat.widget/index.html">androidx.appcompat.widget</a></p>
-</td>
-<td>
-</td>
-</tr>
-<tr>
-<td>
 <p><a href="com.github.zawadz88.materialpopupmenu/index.html">com.github.zawadz88.materialpopupmenu</a></p>
 </td>
 <td>

--- a/docs/material-popup-menu/package-list
+++ b/docs/material-popup-menu/package-list
@@ -1,6 +1,5 @@
 $dokka.format:html
 $dokka.linkExtension:html
 
-androidx.appcompat.widget
 com.github.zawadz88.materialpopupmenu
 com.github.zawadz88.materialpopupmenu.internal

--- a/material-popup-menu/material-popup-menu.gradle
+++ b/material-popup-menu/material-popup-menu.gradle
@@ -74,7 +74,7 @@ ext {
     siteUrl = 'https://github.com/zawadz88/MaterialPopupMenu'
     gitUrl = 'https://github.com/zawadz88/MaterialPopupMenu.git'
 
-    libraryVersion = '3.4.0'
+    libraryVersion = '4.0.0'
 
     developerId = 'zawadz88'
     developerName = 'Piotr Zawadzki'

--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -30,7 +30,9 @@ import java.lang.reflect.Method
 internal class MaterialRecyclerViewPopupWindow(
     private val context: Context,
     private var dropDownGravity: Int,
-    private val fixedContentWidthInPx: Int
+    private val fixedContentWidthInPx: Int,
+    dropDownVerticalOffset: Int?,
+    dropDownHorizontalOffset: Int?
 ) {
 
     companion object {
@@ -117,8 +119,8 @@ internal class MaterialRecyclerViewPopupWindow(
 
         val a = context.obtainStyledAttributes(null, R.styleable.MaterialRecyclerViewPopupWindow)
 
-        dropDownHorizontalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownHorizontalOffset, 0)
-        dropDownVerticalOffset = a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownVerticalOffset, 0)
+        this.dropDownHorizontalOffset = dropDownHorizontalOffset ?: a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownHorizontalOffset, 0)
+        this.dropDownVerticalOffset = dropDownVerticalOffset ?: a.getDimensionPixelOffset(R.styleable.MaterialRecyclerViewPopupWindow_android_dropDownVerticalOffset, 0)
         backgroundDimEnabled = a.getBoolean(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimEnabled, false)
         backgroundDimAmount = a.getFloat(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimAmount, DEFAULT_BACKGROUND_DIM_AMOUNT)
         popupPaddingBottom = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingBottom, 0)
@@ -220,16 +222,20 @@ internal class MaterialRecyclerViewPopupWindow(
         var otherHeights = 0
 
         val dropDownList = View.inflate(context, R.layout.mpm_popup_menu, null) as RecyclerView
-        dropDownList.adapter = adapter
-        dropDownList.layoutManager = LinearLayoutManager(context)
-        dropDownList.isFocusable = true
-        dropDownList.isFocusableInTouchMode = true
-        dropDownList.setPadding(popupPaddingLeft, popupPaddingTop, popupPaddingRight, popupPaddingBottom)
+        dropDownList.also {
+            it.adapter = adapter
+            it.layoutManager = LinearLayoutManager(context)
+            it.isFocusable = true
+            it.isFocusableInTouchMode = true
+            it.setPadding(popupPaddingLeft, popupPaddingTop, popupPaddingRight, popupPaddingBottom)
+        }
+
+        val background = popup.background
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             dropDownList.clipToOutline = true
             // Move the background from popup to RecyclerView for clipToOutline to take effect.
-            dropDownList.background = popup.background
+            dropDownList.background = background
             popup.setBackgroundDrawable(null)
         }
 
@@ -238,7 +244,6 @@ internal class MaterialRecyclerViewPopupWindow(
         // getMaxAvailableHeight() subtracts the padding, so we put it back
         // to get the available height for the whole window.
         val padding: Int
-        val background = popup.background
         if (background != null) {
             background.getPadding(tempRect)
             padding = tempRect.top + tempRect.bottom

--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -102,9 +102,9 @@ internal class MaterialRecyclerViewPopupWindow(
 
     private val popupPaddingBottom: Int
 
-    private val popupPaddingLeft: Int
+    private val popupPaddingStart: Int
 
-    private val popupPaddingRight: Int
+    private val popupPaddingEnd: Int
 
     private val popupPaddingTop: Int
 
@@ -124,8 +124,8 @@ internal class MaterialRecyclerViewPopupWindow(
         backgroundDimEnabled = a.getBoolean(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimEnabled, false)
         backgroundDimAmount = a.getFloat(R.styleable.MaterialRecyclerViewPopupWindow_android_backgroundDimAmount, DEFAULT_BACKGROUND_DIM_AMOUNT)
         popupPaddingBottom = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingBottom, 0)
-        popupPaddingLeft = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingLeft, 0)
-        popupPaddingRight = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingRight, 0)
+        popupPaddingStart = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingStart, 0)
+        popupPaddingEnd = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingEnd, 0)
         popupPaddingTop = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingTop, 0)
 
         a.recycle()
@@ -141,7 +141,7 @@ internal class MaterialRecyclerViewPopupWindow(
 
      * @param width Desired width of content in pixels.
      */
-    internal fun updateContentWidth(width: Int) {
+    private fun updateContentWidth(width: Int) {
         val popupBackground = popup.background
         dropDownWidth = if (popupBackground != null) {
             popupBackground.getPadding(tempRect)
@@ -227,7 +227,7 @@ internal class MaterialRecyclerViewPopupWindow(
             it.layoutManager = LinearLayoutManager(context)
             it.isFocusable = true
             it.isFocusableInTouchMode = true
-            it.setPadding(popupPaddingLeft, popupPaddingTop, popupPaddingRight, popupPaddingBottom)
+            it.setPaddingRelative(popupPaddingStart, popupPaddingTop, popupPaddingEnd, popupPaddingBottom)
         }
 
         val background = popup.background

--- a/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
+++ b/material-popup-menu/src/main/java/androidx/appcompat/widget/MaterialRecyclerViewPopupWindow.kt
@@ -27,9 +27,10 @@ import java.lang.reflect.Method
  * @see ListPopupWindow
  */
 @SuppressLint("PrivateResource,RestrictedApi")
-class MaterialRecyclerViewPopupWindow(
+internal class MaterialRecyclerViewPopupWindow(
     private val context: Context,
-    private var dropDownGravity: Int
+    private var dropDownGravity: Int,
+    private val fixedContentWidthInPx: Int
 ) {
 
     companion object {
@@ -66,7 +67,10 @@ class MaterialRecyclerViewPopupWindow(
 
     internal var adapter: PopupMenuAdapter? = null
         set(value) {
-            setContentWidth(measureIndividualMenuWidth(checkNotNull(value)))
+            val menuWidth = measureMenuSizeAndGetWidth(checkNotNull(value))
+            if (fixedContentWidthInPx == 0) {
+                updateContentWidth(menuWidth)
+            }
             field = value
         }
 
@@ -123,6 +127,10 @@ class MaterialRecyclerViewPopupWindow(
         popupPaddingTop = a.getDimensionPixelSize(R.styleable.MaterialRecyclerViewPopupWindow_mpm_paddingTop, 0)
 
         a.recycle()
+
+        if (fixedContentWidthInPx != 0) {
+            updateContentWidth(fixedContentWidthInPx)
+        }
     }
 
     /**
@@ -131,7 +139,7 @@ class MaterialRecyclerViewPopupWindow(
 
      * @param width Desired width of content in pixels.
      */
-    private fun setContentWidth(width: Int) {
+    internal fun updateContentWidth(width: Int) {
         val popupBackground = popup.background
         dropDownWidth = if (popupBackground != null) {
             popupBackground.getPadding(tempRect)
@@ -145,7 +153,7 @@ class MaterialRecyclerViewPopupWindow(
      * Show the popupMenu list. If the list is already showing, this method
      * will recalculate the popupMenu's size and position.
      */
-    fun show() {
+    internal fun show() {
         checkNotNull(anchorView) { "Anchor view must be set!" }
         val height = buildDropDown()
 
@@ -183,7 +191,7 @@ class MaterialRecyclerViewPopupWindow(
     /**
      * Dismiss the popupMenu window.
      */
-    fun dismiss() {
+    internal fun dismiss() {
         popup.dismiss()
         popup.contentView = null
     }
@@ -193,7 +201,7 @@ class MaterialRecyclerViewPopupWindow(
      *
      * @param listener Listener that is called when this popup window is dismissed.
      */
-    fun setOnDismissListener(listener: (() -> Unit)?) {
+    internal fun setOnDismissListener(listener: (() -> Unit)?) {
         if (listener != null) {
             popup.setOnDismissListener { listener.invoke() }
         } else {
@@ -367,7 +375,7 @@ class MaterialRecyclerViewPopupWindow(
     /**
      * @see android.support.v7.view.menu.MenuPopup.measureIndividualMenuWidth
      */
-    private fun measureIndividualMenuWidth(adapter: PopupMenuAdapter): Int {
+    private fun measureMenuSizeAndGetWidth(adapter: PopupMenuAdapter): Int {
         adapter.setupIndices()
         val parent = FrameLayout(context)
         var menuWidth = popupMinWidth

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -24,10 +24,12 @@ import com.github.zawadz88.materialpopupmenu.internal.PopupMenuAdapter
  */
 class MaterialPopupMenu
 internal constructor(
-    @StyleRes private val style: Int,
-    private val dropdownGravity: Int,
-    private val sections: List<PopupMenuSection>,
-    private val fixedContentWidthInPx: Int
+    @StyleRes internal val style: Int,
+    internal val dropdownGravity: Int,
+    internal val sections: List<PopupMenuSection>,
+    internal val fixedContentWidthInPx: Int,
+    internal val dropDownVerticalOffset: Int?,
+    internal val dropDownHorizontalOffset: Int?
 ) {
 
     private var popupWindow: MaterialRecyclerViewPopupWindow? = null
@@ -45,7 +47,13 @@ internal constructor(
     fun show(context: Context, anchor: View) {
         val style = resolvePopupStyle(context)
         val styledContext = ContextThemeWrapper(context, style)
-        val popupWindow = MaterialRecyclerViewPopupWindow(styledContext, dropdownGravity, fixedContentWidthInPx)
+        val popupWindow = MaterialRecyclerViewPopupWindow(
+            context = styledContext,
+            dropDownGravity = dropdownGravity,
+            fixedContentWidthInPx = fixedContentWidthInPx,
+            dropDownVerticalOffset = dropDownVerticalOffset,
+            dropDownHorizontalOffset = dropDownHorizontalOffset
+        )
         val adapter = PopupMenuAdapter(sections) { popupWindow.dismiss() }
 
         popupWindow.adapter = adapter

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -85,12 +85,12 @@ class MaterialPopupMenu internal constructor(
     }
 
     internal data class PopupMenuSection(
-        val title: String?,
+        val title: CharSequence?,
         val items: List<AbstractPopupMenuItem>
     )
 
     internal data class PopupMenuItem(
-        val label: String?,
+        val label: CharSequence?,
         @StringRes val labelRes: Int,
         @ColorInt val labelColor: Int,
         @DrawableRes val icon: Int,

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenu.kt
@@ -22,10 +22,12 @@ import com.github.zawadz88.materialpopupmenu.internal.PopupMenuAdapter
  *
  * @author Piotr Zawadzki
  */
-class MaterialPopupMenu internal constructor(
-    @StyleRes internal val style: Int,
-    internal val dropdownGravity: Int,
-    internal val sections: List<PopupMenuSection>
+class MaterialPopupMenu
+internal constructor(
+    @StyleRes private val style: Int,
+    private val dropdownGravity: Int,
+    private val sections: List<PopupMenuSection>,
+    private val fixedContentWidthInPx: Int
 ) {
 
     private var popupWindow: MaterialRecyclerViewPopupWindow? = null
@@ -43,7 +45,7 @@ class MaterialPopupMenu internal constructor(
     fun show(context: Context, anchor: View) {
         val style = resolvePopupStyle(context)
         val styledContext = ContextThemeWrapper(context, style)
-        val popupWindow = MaterialRecyclerViewPopupWindow(styledContext, dropdownGravity)
+        val popupWindow = MaterialRecyclerViewPopupWindow(styledContext, dropdownGravity, fixedContentWidthInPx)
         val adapter = PopupMenuAdapter(sections) { popupWindow.dismiss() }
 
         popupWindow.adapter = adapter

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -46,6 +46,16 @@ class MaterialPopupMenuBuilder {
      */
     var fixedContentWidthInPx: Int = 0
 
+    /**
+     * Setting this to non-`null` value will override `android:dropDownVerticalOffset` set by the style applied in [style].
+     */
+    var dropDownVerticalOffset: Int? = null
+
+    /**
+     * Setting this to non-`null` value will override `android:dropDownHorizontalOffset` set by the style applied in [style].
+     */
+    var dropDownHorizontalOffset: Int? = null
+
     private val sectionHolderList = arrayListOf<SectionHolder>()
 
     /**
@@ -76,7 +86,9 @@ class MaterialPopupMenuBuilder {
             style = style,
             dropdownGravity = dropdownGravity,
             sections = sections,
-            fixedContentWidthInPx = fixedContentWidthInPx
+            fixedContentWidthInPx = fixedContentWidthInPx,
+            dropDownVerticalOffset = dropDownVerticalOffset,
+            dropDownHorizontalOffset = dropDownHorizontalOffset
         )
     }
 

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -79,7 +79,7 @@ class MaterialPopupMenuBuilder {
          * Optional section holder. *null* by default.
          * If the title is not *null* it will be displayed in the menu.
          */
-        var title: String? = null
+        var title: CharSequence? = null
 
         private val itemsHolderList = arrayListOf<AbstractItemHolder>()
 
@@ -130,7 +130,7 @@ class MaterialPopupMenuBuilder {
          *
          * If both [label] and [labelRes] are set [label] will be used.
          */
-        var label: String? = null
+        var label: CharSequence? = null
 
         /**
          * Item label.

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilder.kt
@@ -40,6 +40,12 @@ class MaterialPopupMenuBuilder {
      */
     var dropdownGravity: Int = Gravity.NO_GRAVITY
 
+    /**
+     * Setting this to a non-zero value will force the width of the popup menu to be exactly this value.
+     * If set to 0, the default mechanism for measuring popup menu width will be applied.
+     */
+    var fixedContentWidthInPx: Int = 0
+
     private val sectionHolderList = arrayListOf<SectionHolder>()
 
     /**
@@ -66,7 +72,12 @@ class MaterialPopupMenuBuilder {
 
         val sections = sectionHolderList.map { it.convertToPopupMenuSection() }
 
-        return MaterialPopupMenu(style, dropdownGravity, sections)
+        return MaterialPopupMenu(
+            style = style,
+            dropdownGravity = dropdownGravity,
+            sections = sections,
+            fixedContentWidthInPx = fixedContentWidthInPx
+        )
     }
 
     /**

--- a/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
+++ b/material-popup-menu/src/main/java/com/github/zawadz88/materialpopupmenu/internal/PopupMenuAdapter.kt
@@ -40,8 +40,7 @@ internal class PopupMenuAdapter(
     }
 
     override fun getSectionItemViewType(section: Int, position: Int): Int {
-        val popupMenuItem = sections[section].items[position]
-        return when (popupMenuItem) {
+        return when (val popupMenuItem = sections[section].items[position]) {
             is MaterialPopupMenu.PopupMenuCustomItem -> popupMenuItem.layoutResId
             else -> super.getSectionItemViewType(section, position)
         }
@@ -101,7 +100,6 @@ internal class PopupMenuAdapter(
         private var nestedIcon: AppCompatImageView = itemView.findViewById(R.id.mpm_popup_menu_item_nested_icon)
 
         override fun bindItem(popupMenuItem: MaterialPopupMenu.AbstractPopupMenuItem) {
-            super.bindItem(popupMenuItem)
             val castedPopupMenuItem = popupMenuItem as MaterialPopupMenu.PopupMenuItem
             if (castedPopupMenuItem.label != null) {
                 label.text = castedPopupMenuItem.label
@@ -124,6 +122,7 @@ internal class PopupMenuAdapter(
                 label.setTextColor(castedPopupMenuItem.labelColor)
             }
             nestedIcon.visibility = if (castedPopupMenuItem.hasNestedItems) View.VISIBLE else View.GONE
+            super.bindItem(popupMenuItem)
         }
     }
 

--- a/material-popup-menu/src/main/res/layout/mpm_popup_menu_item.xml
+++ b/material-popup-menu/src/main/res/layout/mpm_popup_menu_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/Widget.MPM.Item"
     android:layout_width="match_parent"
     android:layout_height="@dimen/mpm_popup_menu_item_height"
@@ -9,10 +9,8 @@
     android:focusable="true"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
     android:paddingStart="@dimen/mpm_popup_menu_item_padding_horizontal"
+    android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
     tools:ignore="UseCompoundDrawables"
     tools:theme="@style/Widget.MPM.Menu">
 
@@ -21,9 +19,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/mpm_popup_menu_item_icon_margin_end"
-        android:layout_marginRight="@dimen/mpm_popup_menu_item_icon_margin_end"
-        app:tint="?attr/mpm_activeIconColor"
         android:visibility="gone"
+        app:tint="?attr/mpm_activeIconColor"
         tools:ignore="PrivateResource"
         tools:src="@drawable/abc_ic_voice_search_api_material"
         tools:visibility="visible" />
@@ -31,12 +28,12 @@
     <TextView
         android:id="@+id/mpm_popup_menu_item_label"
         android:layout_width="0dp"
-        android:layout_weight="1"
         android:layout_height="wrap_content"
-        android:textAlignment="viewStart"
         android:layout_gravity="start|center_vertical"
+        android:layout_weight="1"
         android:ellipsize="end"
         android:lines="1"
+        android:textAlignment="viewStart"
         android:textColor="?attr/mpm_primaryTextColor"
         android:textSize="@dimen/mpm_popup_menu_item_label_text_size"
         tools:text="Preview" />
@@ -46,10 +43,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/mpm_popup_menu_item_icon_margin_end"
-        android:layout_marginLeft="@dimen/mpm_popup_menu_item_icon_margin_end"
         android:visibility="gone"
-        app:tint="?attr/mpm_activeIconColor"
         app:srcCompat="@drawable/mpm_ic_menu_end"
-        tools:visibility="visible"  />
+        app:tint="?attr/mpm_activeIconColor"
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/material-popup-menu/src/main/res/layout/mpm_popup_menu_section_header.xml
+++ b/material-popup-menu/src/main/res/layout/mpm_popup_menu_section_header.xml
@@ -10,8 +10,8 @@
         android:id="@+id/mpm_popup_menu_section_separator"
         android:layout_width="match_parent"
         android:layout_height="@dimen/mpm_popup_menu_item_section_separator_height"
-        android:layout_marginBottom="@dimen/mpm_popup_menu_item_section_separator_margin_vertical"
         android:layout_marginTop="@dimen/mpm_popup_menu_item_section_separator_margin_vertical"
+        android:layout_marginBottom="@dimen/mpm_popup_menu_item_section_separator_margin_vertical"
         android:background="?attr/mpm_separatorColor"
         tools:visibility="visible" />
 
@@ -19,11 +19,9 @@
         android:id="@+id/mpm_popup_menu_section_header_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/mpm_popup_menu_item_section_label_margin_bottom"
-        android:layout_marginEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
-        android:layout_marginLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
-        android:layout_marginRight="@dimen/mpm_popup_menu_item_padding_horizontal"
         android:layout_marginStart="@dimen/mpm_popup_menu_item_padding_horizontal"
+        android:layout_marginEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
+        android:layout_marginBottom="@dimen/mpm_popup_menu_item_section_label_margin_bottom"
         android:ellipsize="end"
         android:lines="1"
         android:textColor="?attr/mpm_secondaryTextColor"

--- a/material-popup-menu/src/main/res/values/attrs.xml
+++ b/material-popup-menu/src/main/res/values/attrs.xml
@@ -11,9 +11,9 @@
 
     <attr name="mpm_paddingBottom" format="dimension" />
 
-    <attr name="mpm_paddingLeft" format="dimension" />
+    <attr name="mpm_paddingStart" format="dimension" />
 
-    <attr name="mpm_paddingRight" format="dimension" />
+    <attr name="mpm_paddingEnd" format="dimension" />
 
     <attr name="mpm_paddingTop" format="dimension" />
 
@@ -25,8 +25,8 @@
         <attr name="android:backgroundDimEnabled" />
         <attr name="android:backgroundDimAmount" />
         <attr name="mpm_paddingBottom" />
-        <attr name="mpm_paddingLeft" />
-        <attr name="mpm_paddingRight" />
+        <attr name="mpm_paddingStart" />
+        <attr name="mpm_paddingEnd" />
         <attr name="mpm_paddingTop" />
     </declare-styleable>
 

--- a/material-popup-menu/src/main/res/values/styles.xml
+++ b/material-popup-menu/src/main/res/values/styles.xml
@@ -8,8 +8,8 @@
         <item name="mpm_activeIconColor">@color/mpm_black_54_opacity</item>
         <item name="mpm_separatorColor">@color/mpm_black_12_opacity</item>
         <item name="mpm_paddingBottom">@dimen/mpm_popup_menu_vertical_padding</item>
-        <item name="mpm_paddingLeft">0dp</item>
-        <item name="mpm_paddingRight">0dp</item>
+        <item name="mpm_paddingStart">0dp</item>
+        <item name="mpm_paddingEnd">0dp</item>
         <item name="mpm_paddingTop">@dimen/mpm_popup_menu_vertical_padding</item>
     </style>
 
@@ -21,8 +21,8 @@
         <item name="mpm_activeIconColor">@color/mpm_white</item>
         <item name="mpm_separatorColor">@color/mpm_white_12_opacity</item>
         <item name="mpm_paddingBottom">@dimen/mpm_popup_menu_vertical_padding</item>
-        <item name="mpm_paddingLeft">0dp</item>
-        <item name="mpm_paddingRight">0dp</item>
+        <item name="mpm_paddingStart">0dp</item>
+        <item name="mpm_paddingEnd">0dp</item>
         <item name="mpm_paddingTop">@dimen/mpm_popup_menu_vertical_padding</item>
     </style>
 

--- a/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
+++ b/material-popup-menu/src/test/java/com/github/zawadz88/materialpopupmenu/MaterialPopupMenuBuilderTest.kt
@@ -29,6 +29,8 @@ class MaterialPopupMenuBuilderTest {
         private const val CUSTOM_ITEM_LAYOUT = 555
         private const val SECTION_TITLE = "section title"
         private const val SECTION_TITLE2 = "section title2"
+        private const val CUSTOM_WIDTH = 500
+        private const val CUSTOM_OFFSET = 200
     }
 
     @Test(expected = IllegalArgumentException::class)
@@ -124,6 +126,54 @@ class MaterialPopupMenuBuilderTest {
 
         //then
         assertEquals("Invalid popup style", R.style.Widget_MPM_Menu_Dark, popupMenu.style)
+    }
+
+    @Test
+    fun `Should build a popup menu with a custom fixedContentWidthInPx`() {
+        //when
+        val popupMenu = popupMenu {
+            fixedContentWidthInPx = CUSTOM_WIDTH
+            section {
+                item {
+                    label = ITEM_LABEL
+                }
+            }
+        }
+
+        //then
+        assertEquals("Invalid popup fixedContentWidthInPx value", CUSTOM_WIDTH, popupMenu.fixedContentWidthInPx)
+    }
+
+    @Test
+    fun `Should build a popup menu with a custom dropDownHorizontalOffset`() {
+        //when
+        val popupMenu = popupMenu {
+            dropDownHorizontalOffset = CUSTOM_OFFSET
+            section {
+                item {
+                    label = ITEM_LABEL
+                }
+            }
+        }
+
+        //then
+        assertEquals("Invalid popup dropDownHorizontalOffset value", CUSTOM_OFFSET, popupMenu.dropDownHorizontalOffset)
+    }
+
+    @Test
+    fun `Should build a popup menu with a custom dropDownVerticalOffset`() {
+        //when
+        val popupMenu = popupMenu {
+            dropDownVerticalOffset = CUSTOM_OFFSET
+            section {
+                item {
+                    label = ITEM_LABEL
+                }
+            }
+        }
+
+        //then
+        assertEquals("Invalid popup dropDownVerticalOffset value", CUSTOM_OFFSET, popupMenu.dropDownVerticalOffset)
     }
 
     @Test

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import butterknife.BindDimen
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
@@ -46,6 +47,14 @@ class DarkActivity : AppCompatActivity() {
 
     @BindView(R.id.roundedCornersTextView)
     lateinit var roundedCornersTextView: TextView
+
+    @JvmField
+    @BindDimen(R.dimen.horizontal_button_padding)
+    var horizontalButtonPadding: Int = 0
+
+    @JvmField
+    @BindDimen(R.dimen.horizontal_popup_menu_background_start_padding)
+    var horizontalPopupMenuBackgroundStartPadding: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -508,9 +517,11 @@ class DarkActivity : AppCompatActivity() {
     @OnClick(R.id.bottomButton)
     fun onBottomButtonClicked(view: View) {
         val popupMenu = popupMenu {
+            style = R.style.Widget_MPM_Menu_Dark
             dropdownGravity = Gravity.TOP xor Gravity.CENTER_HORIZONTAL
-            style = R.style.Widget_MPM_Menu_Dark_ZeroOffsets
-            fixedContentWidthInPx = view.width
+            fixedContentWidthInPx = calculatePopupMenuWidthForBottomButton(view)
+            dropDownHorizontalOffset = horizontalButtonPadding - horizontalPopupMenuBackgroundStartPadding
+            dropDownVerticalOffset = calculatePopupMenuVerticalOffsetForBottomButton(view)
             section {
                 item {
                     label = "Copy"
@@ -530,6 +541,13 @@ class DarkActivity : AppCompatActivity() {
         }
         popupMenu.show(this@DarkActivity, view)
     }
+
+    private fun calculatePopupMenuWidthForBottomButton(view: View) = view.width - 2 * horizontalButtonPadding
+
+    /**
+     * There was a change in dropdown offsets on Nougat. Before it the popup menu would be displayed on top of the View and not above it.
+     */
+    private fun calculatePopupMenuVerticalOffsetForBottomButton(view: View) = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) view.height else 0
 
     private fun shareUrl() {
         val shareIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SHARE_URL))

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -505,6 +505,32 @@ class DarkActivity : AppCompatActivity() {
         conditionalPopupMenuBuilder.build().show(this@DarkActivity, view)
     }
 
+    @OnClick(R.id.bottomButton)
+    fun onBottomButtonClicked(view: View) {
+        val popupMenu = popupMenu {
+            dropdownGravity = Gravity.TOP xor Gravity.CENTER_HORIZONTAL
+            style = R.style.Widget_MPM_Menu_Dark_ZeroOffsets
+            fixedContentWidthInPx = view.width
+            section {
+                item {
+                    label = "Copy"
+                    icon = R.drawable.abc_ic_menu_copy_mtrl_am_alpha
+                    callback = {
+                        Toast.makeText(this@DarkActivity, "Copied!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                item {
+                    label = "Paste"
+                    icon = R.drawable.abc_ic_menu_paste_mtrl_am_alpha
+                    callback = {
+                        Toast.makeText(this@DarkActivity, "Text pasted!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+        popupMenu.show(this@DarkActivity, view)
+    }
+
     private fun shareUrl() {
         val shareIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SHARE_URL))
         startActivity(shareIntent)

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/DarkActivity.kt
@@ -5,6 +5,10 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
 import android.util.Log
 import android.view.Gravity
 import android.view.Menu
@@ -400,6 +404,14 @@ class DarkActivity : AppCompatActivity() {
                         textView.text = "Some long text that is applied later to see if height calculation indeed is incorrectly calculated due to this binding."
                     }
                 }
+                item {
+                    label = createMultiLineText()
+                    viewBoundCallback = { view ->
+                        val tv = view.findViewById<TextView>(R.id.mpm_popup_menu_item_label)
+                        tv.setSingleLine(false)
+                        tv.maxLines = 2
+                    }
+                }
             }
         }
 
@@ -496,5 +508,26 @@ class DarkActivity : AppCompatActivity() {
     private fun shareUrl() {
         val shareIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SHARE_URL))
         startActivity(shareIntent)
+    }
+
+    private fun createMultiLineText(): CharSequence {
+        val text = "Line 1\nLines in secondary color"
+        val spannable = SpannableString(text)
+        val idx = text.indexOf("\n")
+        if (idx != -1) {
+            spannable.setSpan(
+                RelativeSizeSpan(0.7f),
+                idx,
+                text.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            spannable.setSpan(
+                ForegroundColorSpan(ContextCompat.getColor(this@DarkActivity, R.color.abc_secondary_text_material_dark)),
+                idx,
+                text.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+        return spannable
     }
 }

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -497,6 +497,32 @@ class LightActivity : AppCompatActivity() {
         conditionalPopupMenuBuilder.build().show(this@LightActivity, view)
     }
 
+    @OnClick(R.id.bottomButton)
+    fun onBottomButtonClicked(view: View) {
+        val popupMenu = popupMenu {
+            dropdownGravity = Gravity.TOP xor Gravity.CENTER_HORIZONTAL
+            style = R.style.Widget_MPM_Menu_ZeroOffsets
+            fixedContentWidthInPx = view.width
+            section {
+                item {
+                    label = "Copy"
+                    icon = R.drawable.abc_ic_menu_copy_mtrl_am_alpha
+                    callback = {
+                        Toast.makeText(this@LightActivity, "Copied!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                item {
+                    label = "Paste"
+                    icon = R.drawable.abc_ic_menu_paste_mtrl_am_alpha
+                    callback = {
+                        Toast.makeText(this@LightActivity, "Text pasted!", Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+        popupMenu.show(this@LightActivity, view)
+    }
+
     private fun shareUrl() {
         val shareIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SHARE_URL))
         startActivity(shareIntent)

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -5,6 +5,10 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
 import android.util.Log
 import android.view.Gravity
 import android.view.Menu
@@ -376,6 +380,14 @@ class LightActivity : AppCompatActivity() {
                         textView.text = "Some long text that is applied later to see if height calculation indeed is incorrectly calculated due to this binding."
                     }
                 }
+                item {
+                    label = createMultiLineText()
+                    viewBoundCallback = { view ->
+                        val tv = view.findViewById<TextView>(R.id.mpm_popup_menu_item_label)
+                        tv.setSingleLine(false)
+                        tv.maxLines = 2
+                    }
+                }
             }
         }
 
@@ -488,5 +500,26 @@ class LightActivity : AppCompatActivity() {
     private fun shareUrl() {
         val shareIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SHARE_URL))
         startActivity(shareIntent)
+    }
+
+    private fun createMultiLineText(): CharSequence {
+        val text = "Line 1\nLines in secondary color"
+        val spannable = SpannableString(text)
+        val idx = text.indexOf("\n")
+        if (idx != -1) {
+            spannable.setSpan(
+                RelativeSizeSpan(0.7f),
+                idx,
+                text.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+            spannable.setSpan(
+                ForegroundColorSpan(ContextCompat.getColor(this@LightActivity, R.color.abc_secondary_text_material_light)),
+                idx,
+                text.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
+        }
+        return spannable
     }
 }

--- a/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
+++ b/sample/src/main/java/com/github/zawadz88/materialpopupmenu/sample/LightActivity.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SwitchCompat
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import butterknife.BindDimen
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
@@ -46,6 +47,18 @@ class LightActivity : AppCompatActivity() {
 
     @BindView(R.id.roundedCornersTextView)
     lateinit var roundedCornersTextView: TextView
+
+    @JvmField
+    @BindDimen(R.dimen.horizontal_button_padding)
+    var horizontalButtonPadding: Int = 0
+
+    @JvmField
+    @BindDimen(R.dimen.horizontal_popup_menu_background_start_padding)
+    var popupMenuBackgroundStartMargin: Int = 0
+
+    @JvmField
+    @BindDimen(R.dimen.horizontal_popup_menu_background_start_padding)
+    var horizontalPopupMenuBackgroundStartPadding: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -501,8 +514,9 @@ class LightActivity : AppCompatActivity() {
     fun onBottomButtonClicked(view: View) {
         val popupMenu = popupMenu {
             dropdownGravity = Gravity.TOP xor Gravity.CENTER_HORIZONTAL
-            style = R.style.Widget_MPM_Menu_ZeroOffsets
-            fixedContentWidthInPx = view.width
+            fixedContentWidthInPx = calculatePopupMenuWidthForBottomButton(view)
+            dropDownHorizontalOffset = horizontalButtonPadding - horizontalPopupMenuBackgroundStartPadding
+            dropDownVerticalOffset = calculateVerticalOffsetForBottomButton(view)
             section {
                 item {
                     label = "Copy"
@@ -522,6 +536,13 @@ class LightActivity : AppCompatActivity() {
         }
         popupMenu.show(this@LightActivity, view)
     }
+
+    private fun calculatePopupMenuWidthForBottomButton(view: View) = view.width - 2 * horizontalButtonPadding
+
+    /**
+     * There was a change in dropdown offsets on Nougat. Before it the popup menu would be displayed on top of the View and not above it.
+     */
+    private fun calculateVerticalOffsetForBottomButton(view: View) = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) view.height else 0
 
     private fun shareUrl() {
         val shareIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Constants.SHARE_URL))

--- a/sample/src/main/res/layout/activity_dark.xml
+++ b/sample/src/main/res/layout/activity_dark.xml
@@ -168,6 +168,20 @@
                 app:layout_constraintBaseline_toBaselineOf="@+id/conditionalItemsSectionSubtitleTextView"
                 app:layout_constraintRight_toRightOf="parent" />
 
+            <Button
+                android:id="@+id/bottomButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:text="@string/bottom_button_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/conditionalItemsSectionSubtitleTextView" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/sample/src/main/res/layout/activity_dark.xml
+++ b/sample/src/main/res/layout/activity_dark.xml
@@ -32,7 +32,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/single_section_with_icons"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
@@ -41,7 +41,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/single_section_without_icons"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/singleSectionWithIcons" />
 
             <TextView
@@ -50,7 +50,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/two_sections_with_section_titles"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/singleSectionWithoutIcons" />
 
             <TextView
@@ -59,7 +59,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/two_sections_without_titles"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsWithTitlesTextView" />
 
             <TextView
@@ -68,7 +68,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_colors"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsWithoutTitlesTextView" />
 
             <TextView
@@ -77,7 +77,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_items"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsWithoutTitlesTextView" />
 
             <TextView
@@ -86,7 +86,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_offsets"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customColorsTextView" />
 
             <TextView
@@ -95,7 +95,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/dimmed_background"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
 
             <TextView
@@ -104,7 +104,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_padding"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
 
             <TextView
@@ -113,7 +113,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/rounded_corners"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
 
             <TextView
@@ -122,7 +122,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/roundedCornersTextView" />
 
             <TextView
@@ -131,9 +131,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/show_copy_item"
+                app:layout_constraintEnd_toStartOf="@+id/copyConditionalSwitch"
                 app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@+id/copyConditionalSwitch"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/conditionalItemsTextView" />
 
             <androidx.appcompat.widget.SwitchCompat
@@ -141,10 +141,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
                 android:checked="true"
                 app:layout_constraintBaseline_toBaselineOf="@+id/conditionalItemsCopySubtitleTextView"
-                app:layout_constraintRight_toRightOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent" />
 
             <TextView
                 android:id="@+id/conditionalItemsSectionSubtitleTextView"
@@ -153,9 +152,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:text="@string/show_share_section"
+                app:layout_constraintEnd_toStartOf="@+id/sectionConditionalSwitch"
                 app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@+id/sectionConditionalSwitch"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/conditionalItemsCopySubtitleTextView" />
 
             <androidx.appcompat.widget.SwitchCompat
@@ -163,20 +162,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
                 android:checked="true"
                 app:layout_constraintBaseline_toBaselineOf="@+id/conditionalItemsSectionSubtitleTextView"
-                app:layout_constraintRight_toRightOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent" />
 
             <Button
                 android:id="@+id/bottomButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:layout_marginLeft="8dp"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
                 android:text="@string/bottom_button_text"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/sample/src/main/res/layout/activity_light.xml
+++ b/sample/src/main/res/layout/activity_light.xml
@@ -168,6 +168,20 @@
                 app:layout_constraintBaseline_toBaselineOf="@+id/conditionalItemsSectionSubtitleTextView"
                 app:layout_constraintRight_toRightOf="parent" />
 
+            <Button
+                android:id="@+id/bottomButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginLeft="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
+                android:layout_marginRight="8dp"
+                android:text="@string/bottom_button_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/conditionalItemsSectionSubtitleTextView" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/sample/src/main/res/layout/activity_light.xml
+++ b/sample/src/main/res/layout/activity_light.xml
@@ -32,7 +32,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/single_section_with_icons"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
@@ -41,7 +41,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/single_section_without_icons"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/singleSectionWithIcons" />
 
             <TextView
@@ -50,7 +50,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/two_sections_with_section_titles"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/singleSectionWithoutIcons" />
 
             <TextView
@@ -59,7 +59,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/two_sections_without_titles"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsWithTitlesTextView" />
 
             <TextView
@@ -68,7 +68,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_colors"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsWithoutTitlesTextView" />
 
             <TextView
@@ -77,7 +77,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_items"
-                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/sectionsWithoutTitlesTextView" />
 
             <TextView
@@ -86,7 +86,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_offsets"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customColorsTextView" />
 
             <TextView
@@ -95,7 +95,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/dimmed_background"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customOffsetsTextView" />
 
             <TextView
@@ -104,7 +104,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/custom_padding"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/dimmedBackgroundTextView" />
 
             <TextView
@@ -113,7 +113,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/rounded_corners"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/customPaddingTextView" />
 
             <TextView
@@ -122,7 +122,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/conditional_items"
-                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/roundedCornersTextView" />
 
             <TextView
@@ -131,9 +131,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/show_copy_item"
+                app:layout_constraintEnd_toStartOf="@+id/copyConditionalSwitch"
                 app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@+id/copyConditionalSwitch"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/conditionalItemsTextView" />
 
             <androidx.appcompat.widget.SwitchCompat
@@ -141,10 +141,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
                 android:checked="true"
                 app:layout_constraintBaseline_toBaselineOf="@+id/conditionalItemsCopySubtitleTextView"
-                app:layout_constraintRight_toRightOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent" />
 
             <TextView
                 android:id="@+id/conditionalItemsSectionSubtitleTextView"
@@ -153,9 +152,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:text="@string/show_share_section"
+                app:layout_constraintEnd_toStartOf="@+id/sectionConditionalSwitch"
                 app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@+id/sectionConditionalSwitch"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/conditionalItemsCopySubtitleTextView" />
 
             <androidx.appcompat.widget.SwitchCompat
@@ -163,20 +162,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="16dp"
-                android:layout_marginRight="16dp"
                 android:checked="true"
                 app:layout_constraintBaseline_toBaselineOf="@+id/conditionalItemsSectionSubtitleTextView"
-                app:layout_constraintRight_toRightOf="parent" />
+                app:layout_constraintEnd_toEndOf="parent" />
 
             <Button
                 android:id="@+id/bottomButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:layout_marginLeft="8dp"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
                 android:text="@string/bottom_button_text"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -12,38 +12,34 @@
         android:layout_height="wrap_content"
         android:background="@color/colorPrimary"
         android:elevation="4dp"
-        app:titleTextColor="@android:color/white"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:titleTextColor="@android:color/white"
         tools:ignore="UnusedAttribute" />
 
     <Button
         android:id="@+id/light_activity"
         android:layout_width="200dp"
         android:layout_height="wrap_content"
-        android:text="@string/light_activity"
-        android:layout_marginRight="8dp"
-        app:layout_constraintRight_toRightOf="parent"
-        android:layout_marginLeft="8dp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        android:layout_marginTop="8dp"
         android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
+        android:text="@string/light_activity"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/toolbar" />
 
     <Button
         android:id="@+id/dark_activity"
         android:layout_width="200dp"
         android:layout_height="wrap_content"
-        android:text="@string/dark_activity"
-        android:layout_marginRight="8dp"
-        app:layout_constraintRight_toRightOf="parent"
-        android:layout_marginLeft="8dp"
-        app:layout_constraintLeft_toLeftOf="parent"
-        android:layout_marginTop="8dp"
         android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
+        android:text="@string/dark_activity"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/light_activity" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/view_custom_item_checkable.xml
+++ b/sample/src/main/res/layout/view_custom_item_checkable.xml
@@ -9,8 +9,6 @@
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
     android:paddingStart="@dimen/mpm_popup_menu_item_padding_horizontal"
     tools:ignore="UseCompoundDrawables"
     tools:theme="@style/Widget.MPM.Menu">

--- a/sample/src/main/res/layout/view_custom_item_colored.xml
+++ b/sample/src/main/res/layout/view_custom_item_colored.xml
@@ -6,10 +6,8 @@
     android:clickable="true"
     android:focusable="true"
     android:paddingStart="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
     android:paddingTop="@dimen/mpm_popup_menu_vertical_padding"
     android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
     android:paddingBottom="@dimen/mpm_popup_menu_vertical_padding"
     android:text="@string/more"
     android:textColor="@android:color/white" />

--- a/sample/src/main/res/layout/view_custom_item_large.xml
+++ b/sample/src/main/res/layout/view_custom_item_large.xml
@@ -10,9 +10,7 @@
     android:gravity="center"
     android:orientation="vertical"
     android:paddingStart="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingLeft="@dimen/mpm_popup_menu_item_padding_horizontal"
     android:paddingEnd="@dimen/mpm_popup_menu_item_padding_horizontal"
-    android:paddingRight="@dimen/mpm_popup_menu_item_padding_horizontal"
     tools:ignore="UseCompoundDrawables"
     tools:theme="@style/Widget.MPM.Menu">
 

--- a/sample/src/main/res/values-v21/dimens.xml
+++ b/sample/src/main/res/values-v21/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="horizontal_popup_menu_background_start_padding">0dp</dimen>
+</resources>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="horizontal_button_padding">4dp</dimen>
+    <dimen name="horizontal_popup_menu_background_start_padding">8dp</dimen>
+</resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="dimmed_background">Dimmed background</string>
     <string name="custom_padding">Custom padding</string>
     <string name="rounded_corners">Rounded corners</string>
+    <string name="bottom_button_text">Show menu above me please</string>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -26,8 +26,8 @@
     </style>
 
     <style name="TitleLabel" parent="Base.TitleLabel">
-        <item name="android:layout_marginLeft">16dp</item>
-        <item name="android:layout_marginRight">16dp</item>
+        <item name="android:layout_marginStart">16dp</item>
+        <item name="android:layout_marginEnd">16dp</item>
         <item name="android:layout_marginTop">8dp</item>
         <item name="android:paddingBottom">16dp</item>
         <item name="android:paddingTop">16dp</item>
@@ -35,7 +35,7 @@
     </style>
 
     <style name="SubtitleLabel">
-        <item name="android:layout_marginLeft">16dp</item>
+        <item name="android:layout_marginStart">16dp</item>
         <item name="android:layout_marginTop">0dp</item>
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Caption</item>
     </style>
@@ -64,15 +64,15 @@
 
     <style name="Widget.MPM.Menu.CustomPadding">
         <item name="mpm_paddingBottom">16dp</item>
-        <item name="mpm_paddingLeft">16dp</item>
-        <item name="mpm_paddingRight">16dp</item>
+        <item name="mpm_paddingStart">16dp</item>
+        <item name="mpm_paddingEnd">16dp</item>
         <item name="mpm_paddingTop">16dp</item>
     </style>
 
     <style name="Widget.MPM.Menu.Dark.CustomPadding">
         <item name="mpm_paddingBottom">16dp</item>
-        <item name="mpm_paddingLeft">16dp</item>
-        <item name="mpm_paddingRight">16dp</item>
+        <item name="mpm_paddingStart">16dp</item>
+        <item name="mpm_paddingEnd">16dp</item>
         <item name="mpm_paddingTop">16dp</item>
     </style>
 

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -54,6 +54,16 @@
         <item name="android:dropDownHorizontalOffset">24dp</item>
     </style>
 
+    <style name="Widget.MPM.Menu.ZeroOffsets">
+        <item name="android:dropDownVerticalOffset">0dp</item>
+        <item name="android:dropDownHorizontalOffset">0dp</item>
+    </style>
+
+    <style name="Widget.MPM.Menu.Dark.ZeroOffsets">
+        <item name="android:dropDownVerticalOffset">0dp</item>
+        <item name="android:dropDownHorizontalOffset">0dp</item>
+    </style>
+
     <style name="Widget.MPM.Menu.Dimmed">
         <item name="android:backgroundDimEnabled">true</item>
     </style>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -54,16 +54,6 @@
         <item name="android:dropDownHorizontalOffset">24dp</item>
     </style>
 
-    <style name="Widget.MPM.Menu.ZeroOffsets">
-        <item name="android:dropDownVerticalOffset">0dp</item>
-        <item name="android:dropDownHorizontalOffset">0dp</item>
-    </style>
-
-    <style name="Widget.MPM.Menu.Dark.ZeroOffsets">
-        <item name="android:dropDownVerticalOffset">0dp</item>
-        <item name="android:dropDownHorizontalOffset">0dp</item>
-    </style>
-
     <style name="Widget.MPM.Menu.Dimmed">
         <item name="android:backgroundDimEnabled">true</item>
     </style>


### PR DESCRIPTION
## [4.0.0]
### Changed
- ***Breaking change:*** minimum SDK version raised to API 19 (Kitkat).
- ***Breaking change:*** replaced `mpm_paddingLeft` with `mpm_paddingStart` and `mpm_paddingRight` with `mpm_paddingEnd` and other inter layout attributes accordingly for better RTL support
- ***Breaking change:*** updated `MaterialPopupMenuBuilder.SectionHolder.label` and `MaterialPopupMenuBuilder.ItemHolder.label` to be of type `CharSequence` rather than `String` to allow the use of `Spannables`.
- Moved `super.bindItem` call to the end of `ItemViewHolder#bindItem`method so that it's possible to override values set by it in callbacks.

### Added
- an option to override the defaults and set menu width & dropdown offsets programmatically via `MaterialPopupMenuBuilder` e.g. to achieve the following
![Screenshot_1562347760](https://user-images.githubusercontent.com/3322260/60737481-3a45bd00-9f5b-11e9-9629-3bcd1a2045d6.png)

